### PR TITLE
installation: bump `yadageschemas` to 0.7.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -66,6 +66,10 @@ install_requires = [
     'bravado>=9.0.6',
     'click>=6.7',
     'yadage-schemas==0.7.4',
+    'pyOpenSSL==17.3.0',  # FIXME remove once yadage-schemas solves deps.
+    'rfc3987==1.3.7',  # FIXME remove once yadage-schemas solves deps.
+    'strict-rfc3339==0.7',  # FIXME remove once yadage-schemas solves deps.
+    'webcolors==1.7',  # FIXME remove once yadage-schemas solves deps.
 ]
 
 packages = find_packages()

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ setup_requires = [
 install_requires = [
     'bravado>=9.0.6',
     'click>=6.7',
-    'yadage-schemas==0.6.0',
+    'yadage-schemas==0.7.4',
 ]
 
 packages = find_packages()


### PR DESCRIPTION
* Because of reanahub/reana-workflow-engine-yadage#36
  we use `yadageschemas=0.7.4`

Signed-off-by: Diego Rodriguez <diego.rodriguez@cern.ch>