### PR TITLE
cli: pass spec file as parameter `reana run`

### DIFF
--- a/reana_client/api/client.py
+++ b/reana_client/api/client.py
@@ -25,7 +25,6 @@ import json
 import os
 
 import pkg_resources
-
 from bravado.client import SwaggerClient
 
 

--- a/reana_client/cli/__init__.py
+++ b/reana_client/cli/__init__.py
@@ -36,11 +36,12 @@ class Config(object):
 
     def __init__(self):
         """Initialize config variables."""
-        server = os.environ.get('REANA_SERVER_URL', 'http://reana.cern.ch')
+        server_url = os.environ.get('REANA_SERVER_URL', 'http://reana.cern.ch')
 
-        logging.info('REANA Server URL set to: {}'.format(server))
+        logging.info('REANA Server URL ($REANA_SERVER_URL) is: {}'
+                     .format(server_url))
 
-        self.client = Client(server)
+        self.client = Client(server_url)
 
 
 @click.group()

--- a/reana_client/config.py
+++ b/reana_client/config.py
@@ -23,10 +23,16 @@
 
 import pkg_resources
 
-reana_yaml_file_path = '.reana.yaml'
-"""REANA specification file location.."""
+reana_yaml_default_file_path = './.reana.yaml'  # e.g. `./.reana.yaml`
+"""REANA specification file default location."""
 
 reana_yaml_schema_file_path = pkg_resources.resource_filename(
         __name__,
         'schemas/reana_analysis_schema.json')
 """REANA specification schema location."""
+
+default_user = '00000000-0000-0000-0000-000000000000'
+"""Default user to use when submitting workflows to Reana Server."""
+
+default_organisation = 'default'
+"""Default organisation to use when submitting workflows to Reana Server."""

--- a/reana_client/utils.py
+++ b/reana_client/utils.py
@@ -23,7 +23,7 @@
 
 import json
 import logging
-from config import reana_yaml_file_path, reana_yaml_schema_file_path
+from config import reana_yaml_schema_file_path
 
 import yadageschemas
 import yaml
@@ -59,23 +59,28 @@ def load_workflow_spec(workflow_type, workflow_file, **kwargs):
     return workflow_load[workflow_type](workflow_file, **kwargs)
 
 
-def load_reana_spec():
+def load_reana_spec(filepath, skip_validation=False):
     """Load and validate reana specification file.
 
-    :raises IOError: Error while reading `reana_yaml_file_path`.
-    :raises ValidationError:g `reana_yaml_file_path` does not validate against
+    :raises IOError: Error while reading REANA spec file from given filepath`.
+    :raises ValidationError: Given REANA spec file does not validate against
         REANA specification.
     """
     try:
-        with open(reana_yaml_file_path) as f:
+        with open(filepath) as f:
             reana_yaml = yaml.load(f.read())
 
-        _validate_reana_yaml(reana_yaml)
+        if not (skip_validation):
+            logging.info('Validating REANA specification file: {filepath}'
+                         .format(filepath=filepath))
+            _validate_reana_yaml(reana_yaml)
+
         return reana_yaml
     except IOError as e:
         logging.info(
-            'Something went wrong when reading .reana.yaml: {0}'.format(
-                e.strerror))
+            'Something went wrong when reading specifications file from '
+            '{filepath} : \n'
+            '{error}'.format(filepath=filepath, error=e.strerror))
         raise e
     except Exception as e:
         raise e
@@ -84,9 +89,9 @@ def load_reana_spec():
 def _validate_reana_yaml(reana_yaml):
     """Validate REANA specification file according to jsonschema.
 
-    :param reana_yaml: Dictionary which represents `.reana.yaml`.
-    :raises ValidationError: `reana_yaml` does not validate against REANA
-        specification.
+    :param reana_yaml: Dictionary which represents REANA specifications file.
+    :raises ValidationError: Given REANA spec file does not validate against
+        REANA specification schema.
     """
     try:
         with open(reana_yaml_schema_file_path, 'r') as f:
@@ -96,10 +101,12 @@ def _validate_reana_yaml(reana_yaml):
 
     except IOError as e:
         logging.info(
-            'Something went wrong when reading {0}: {1}'.format(
-                reana_yaml_schema_file_path, e.strerror))
+            'Something went wrong when reading REANA validation schema from '
+            '{filepath} : \n'
+            '{error}'.format(filepath=reana_yaml_schema_file_path,
+                             error=e.strerror))
         raise e
     except ValidationError as e:
-        logging.info('Invalid `.reana.yaml` specification: {0}'.format(
-            e.message))
+        logging.info('Invalid REANA specification: {error}'
+                     .format(error=e.message))
         raise e


### PR DESCRIPTION
  * Add `-f / --file` option to `reana run` command that specifies which
    REANA specifications file should be used.
    (addresses #14)

  * Add `--skip-validation` option to `reana run` command in order to
    skip validation of the given specifications file, before submitting
    it to Reana Server.
    (addresses #19)

Signed-off-by: Harri Hirvonsalo <harri.hirvonsalo@cern.ch>