### PR TITLE
installation: declare Python 2.7 support only

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -110,6 +110,8 @@ setup(
         'Programming Language :: Python',
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
         'Topic :: Software Development :: Libraries :: Python Modules',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
         'Development Status :: 3 - Alpha',
     ],
 )


### PR DESCRIPTION
* Declares support for Python 2.7 only in `setup.py`. (see #17)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>