### PR TITLE
cli: add `reana validate` command

### DIFF
--- a/reana_client/cli/__init__.py
+++ b/reana_client/cli/__init__.py
@@ -64,3 +64,4 @@ def cli(ctx, loglevel):
 cli.add_command(ping.ping)
 cli.add_command(analyses.list_)
 cli.add_command(analyses.run)
+cli.add_command(analyses.validate)

--- a/reana_client/cli/analyses.py
+++ b/reana_client/cli/analyses.py
@@ -30,6 +30,28 @@ from ..config import (default_organisation, default_user,
 from ..utils import load_reana_spec, load_workflow_spec
 
 
+@click.command()
+@click.option('-f',
+              '--file',
+              type=click.Path(exists=True, resolve_path=True),
+              default=reana_yaml_default_file_path,
+              help='REANA specifications file describing the workflow and '
+                   'context which REANA should execute.')
+@click.pass_context
+def validate(ctx, file):
+    """Validate given REANA specification file."""
+    try:
+        load_reana_spec(click.format_filename(file))
+
+        click.echo('File {filename} is a valid REANA specification file.'
+                   .format(filename=click.format_filename(file)))
+
+    except Exception as e:
+        logging.info('Something went wrong when trying to validate {0}'
+                     .format(click.format_filename(file)))
+        logging.debug(str(e))
+
+
 @click.command('list')
 @click.pass_context
 def list_(ctx):


### PR DESCRIPTION
  * Add `reana validate` command to validate a REANA specification file.
    Uses either default value (e.g. .reana.yml) or a file specified with
    `-f / --file` -option (e.g. `reana validate -f my-spec-file.yml`).
    (closes #19)

Signed-off-by: Harri Hirvonsalo <harri.hirvonsalo@cern.ch>