### PR TITLE
docs: fix for ``--workflow`` CLI argument

### DIFF
--- a/docs/gettingstarted.rst
+++ b/docs/gettingstarted.rst
@@ -75,7 +75,7 @@ and check its status:
    -----------|------------------------------------|------------------------------------|------------|-------
    lucid_kirch|57c917c8-d979-481e-ae4c-8d8b9ffb2d10|00000000-0000-0000-0000-000000000000|default     |created
 
-Note that instead of passing ``--workflow-id`` argument, we can define a new
+Note that instead of passing ``--workflow`` argument, we can define a new
 environment variable ``REANA_WORKON`` which specifies the workflow we are
 currently working on:
 

--- a/docs/userguide.rst
+++ b/docs/userguide.rst
@@ -20,7 +20,7 @@ REANA_WORKON
 ~~~~~~~~~~~~
 
 Permits to specify a concrete workflow ID run for the given analysis. (As an
-alternative to specifying ``--workflow-id`` in commands.) For example:
+alternative to specifying ``--workflow`` in commands.) For example:
 
 .. code-block:: console
 


### PR DESCRIPTION
* Uses ``-workflow`` CLI argument instead of ``--workflow-id``.

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>