### PR TITLE
cli: support file seeding with absolute paths

### DIFF
--- a/reana_client/api/client.py
+++ b/reana_client/api/client.py
@@ -479,26 +479,21 @@ class Client(object):
                 for root, dirs, files in os.walk(path, topdown=False):
                     responses = []
                     for next_path in files + dirs:
-                        try:
-                            response = self.upload_to_server(
-                                user, organization, workflow,
-                                os.path.join(root, next_path),
-                                upload_type)
-                            responses.append(os.path.join(root, next_path))
-                        except Exception as e:
-                            logging.error(traceback.format_exc())
-                            logging.error("Something went wrong"
-                                          " while uploading '{0}'".
-                                          format(os.path.join(root,
-                                                              next_path)))
+                        response = self.upload_to_server(
+                            user, organization, workflow,
+                            os.path.join(root, next_path),
+                            upload_type)
+                        responses.append(os.path.join(root, next_path))
                 return responses
 
             # Check if input is an absolute path and upload file.
             else:
                 with open(path) as f:
                     fname = os.path.basename(f.name)
-                    if len(path.split('/')) > 1 and \
-                            path.split('/')[0] == UploadType(upload_type).name:
+                    # Remove prepending dirs named "." or as the upload type
+                    while len(path.split('/')) > 1 and \
+                            path.split('/')[0] in \
+                            [UploadType(upload_type).name, '.']:
                         path = "/".join(path.strip("/").split('/')[1:])
                     logging.debug("'{}' is an absolute filepath."
                                   .format(os.path.basename(fname)))
@@ -517,9 +512,9 @@ class Client(object):
                         if response:
                             logging.info("File '{}' was successfully "
                                          "uploaded.".format(fname))
-                        return response
                     except Exception as e:
-                        logging.error(traceback.format_exc())
-                        logging.error("Something went wrong"
-                                      " while uploading '{0}'".
-                                      format(path))
+                        logging.debug(traceback.format_exc())
+                        logging.debug(str(e))
+                        logging.info("Something went wrong while uploading {}".
+                                     format(fname))
+                    return response

--- a/reana_client/cli/analyses.py
+++ b/reana_client/cli/analyses.py
@@ -38,7 +38,7 @@ from jsonschema.exceptions import ValidationError
 @click.pass_context
 def analyses(ctx):
     """Top level wrapper for analysis related interaction."""
-    logging.debug('analysis')
+    logging.debug(ctx.info_name)
 
 
 @click.command('validate')
@@ -52,9 +52,9 @@ def analyses(ctx):
 @click.pass_context
 def analysis_validate(ctx, file):
     """Validate given REANA specification file."""
-    logging.debug('analysis.validate')
-    logging.debug('file: {}'.format(file))
-
+    logging.debug('command: {}'.format(ctx.command_path.replace(" ", ".")))
+    for p in ctx.params:
+        logging.debug('{param}: {value}'.format(param=p, value=ctx.params[p]))
     try:
         load_reana_spec(click.format_filename(file))
         click.echo(

--- a/reana_client/cli/code.py
+++ b/reana_client/cli/code.py
@@ -111,7 +111,7 @@ def code_list(ctx, user, organization, workflow, filter, output_format):
 @click.argument(
     'filenames',
     metavar='FILE',
-    type=click.Path(exists=False, resolve_path=False),
+    type=click.Path(exists=True, resolve_path=False),
     nargs=-1)
 @click.option(
     '-u',
@@ -167,8 +167,7 @@ def code_upload(ctx, user, organization, workflow, filenames):
                 logging.debug(str(e))
                 click.echo(
                     click.style(
-                        'Something went wrong while uploading {0}'.
-                        format(filename),
+                        '{0}'.format(str(e)),
                         fg='red'),
                     err=True)
 

--- a/reana_client/cli/code.py
+++ b/reana_client/cli/code.py
@@ -111,7 +111,7 @@ def code_list(ctx, user, organization, workflow, filter, output_format):
 @click.argument(
     'filenames',
     metavar='FILE',
-    type=click.Path(exists=True, resolve_path=False),
+    type=click.Path(exists=True, resolve_path=True),
     nargs=-1)
 @click.option(
     '-u',
@@ -159,7 +159,8 @@ def code_upload(ctx, user, organization, workflow, filenames):
                 logging.debug(str(e))
                 click.echo(
                     click.style(
-                        '{0}: {1}'.format(filename, str(e)),
+                        'Something went wrong while uploading {0}.\n{1}'.
+                        format(filename, str(e)),
                         fg='red'),
                     err=True)
             except Exception as e:
@@ -167,7 +168,8 @@ def code_upload(ctx, user, organization, workflow, filenames):
                 logging.debug(str(e))
                 click.echo(
                     click.style(
-                        '{0}'.format(str(e)),
+                        'Something went wrong while uploading {}'.
+                        format(filename),
                         fg='red'),
                     err=True)
 

--- a/reana_client/cli/inputs.py
+++ b/reana_client/cli/inputs.py
@@ -109,7 +109,7 @@ def inputs_list(ctx, user, organization, workflow, filter, output_format):
 @click.argument(
     'filenames',
     metavar='FILE',
-    type=click.Path(exists=True, resolve_path=True),
+    type=click.Path(exists=True, resolve_path=False),
     nargs=-1)
 @click.option(
     '-u',
@@ -153,8 +153,7 @@ def inputs_upload(ctx, user, organization, workflow, filenames):
                 logging.debug(str(e))
                 click.echo(
                     click.style(
-                        'Something went wrong while uploading {0}'.
-                        format(filename),
+                        '{0}'.format(str(e)),
                         fg='red'),
                     err=True)
 

--- a/reana_client/cli/inputs.py
+++ b/reana_client/cli/inputs.py
@@ -29,6 +29,7 @@ import click
 import tablib
 
 from ..config import default_organization, default_user
+from ..errors import FileUploadError
 from ..api.client import UploadType
 
 
@@ -109,7 +110,7 @@ def inputs_list(ctx, user, organization, workflow, filter, output_format):
 @click.argument(
     'filenames',
     metavar='FILE',
-    type=click.Path(exists=True, resolve_path=False),
+    type=click.Path(exists=True, resolve_path=True),
     nargs=-1)
 @click.option(
     '-u',
@@ -147,13 +148,22 @@ def inputs_upload(ctx, user, organization, workflow, filenames):
                     click.echo(
                         click.style('File {} was successfully uploaded.'.
                                     format(filename), fg='green'))
-
+            except FileUploadError as e:
+                logging.debug(traceback.format_exc())
+                logging.debug(str(e))
+                click.echo(
+                    click.style(
+                        'Something went wrong while uploading {0}.\n{1}'.
+                        format(filename, str(e)),
+                        fg='red'),
+                    err=True)
             except Exception as e:
                 logging.debug(traceback.format_exc())
                 logging.debug(str(e))
                 click.echo(
                     click.style(
-                        '{0}'.format(str(e)),
+                        'Something went wrong while uploading {}'.
+                        format(filename),
                         fg='red'),
                     err=True)
 

--- a/reana_client/cli/workflow.py
+++ b/reana_client/cli/workflow.py
@@ -48,7 +48,7 @@ class _WorkflowStatus(Enum):
 @click.pass_context
 def workflow(ctx):
     """Top level wrapper for workflow related interaction."""
-    logging.debug('workflow')
+    logging.debug(ctx.info_name)
 
 
 @click.command(
@@ -77,11 +77,9 @@ def workflow(ctx):
 @click.pass_context
 def workflow_list(ctx, user, organization, filter, output_format):
     """List all workflows user has."""
-    logging.debug('workflow.list')
-    logging.debug('user: {}'.format(user))
-    logging.debug('organization: {}'.format(organization))
-    logging.debug('filter: {}'.format(filter))
-    logging.debug('output_format: {}'.format(output_format))
+    logging.debug('command: {}'.format(ctx.command_path.replace(" ", ".")))
+    for p in ctx.params:
+        logging.debug('{param}: {value}'.format(param=p, value=ctx.params[p]))
 
     data = tablib.Dataset()
     data.headers = ['name', 'run_number', 'id', 'user', 'organization',
@@ -150,11 +148,9 @@ def workflow_list(ctx, user, organization, filter, output_format):
 @click.pass_context
 def workflow_create(ctx, file, user, name, organization, skip_validation):
     """Create a REANA compatible analysis workflow from REANA spec file."""
-    logging.debug('workflow.create')
-    logging.debug('file: {}'.format(file))
-    logging.debug('user: {}'.format(user))
-    logging.debug('organization: {}'.format(organization))
-    logging.debug('skip_validation: {}'.format(skip_validation))
+    logging.debug('command: {}'.format(ctx.command_path.replace(" ", ".")))
+    for p in ctx.params:
+        logging.debug('{param}: {value}'.format(param=p, value=ctx.params[p]))
 
     # Check that name is not an UUIDv4.
     # Otherwise it would mess up `--workflow` flag usage because no distinction
@@ -206,6 +202,7 @@ def workflow_create(ctx, file, user, name, organization, skip_validation):
     default=default_organization,
     help='Organization whose resources will be used.')
 @click.option(
+    '-w',
     '--workflow',
     default=os.environ.get('REANA_WORKON', None),
     callback=workflow_uuid_or_name,
@@ -214,10 +211,9 @@ def workflow_create(ctx, file, user, name, organization, skip_validation):
 @click.pass_context
 def workflow_start(ctx, user, organization, workflow):
     """Start previously created analysis workflow."""
-    logging.debug('workflow.start')
-    logging.debug('user: {}'.format(user))
-    logging.debug('organization: {}'.format(organization))
-    logging.debug('workflow: {}'.format(workflow))
+    logging.debug('command: {}'.format(ctx.command_path.replace(" ", ".")))
+    for p in ctx.params:
+        logging.debug('{param}: {value}'.format(param=p, value=ctx.params[p]))
 
     logging.info('Workflow `{}` selected'.format(workflow))
     click.echo('Workflow `{}` selected.'.format(workflow))
@@ -256,6 +252,7 @@ def workflow_start(ctx, user, organization, workflow):
     default=default_organization,
     help='Organization whose resources will be used.')
 @click.option(
+    '-w',
     '--workflow',
     default=os.environ.get('REANA_WORKON', None),
     callback=workflow_uuid_or_name,
@@ -274,12 +271,9 @@ def workflow_start(ctx, user, organization, workflow):
 @click.pass_context
 def workflow_status(ctx, user, organization, workflow, filter, output_format):
     """Get status of previously created analysis workflow."""
-    logging.debug('workflow.start')
-    logging.debug('user: {}'.format(user))
-    logging.debug('organization: {}'.format(organization))
-    logging.debug('workflow: {}'.format(workflow))
-    logging.debug('output_format: {}'.format(output_format))
-    logging.info('Workflow "{}" selected'.format(workflow))
+    logging.debug('command: {}'.format(ctx.command_path.replace(" ", ".")))
+    for p in ctx.params:
+        logging.debug('{param}: {value}'.format(param=p, value=ctx.params[p]))
 
     data = tablib.Dataset()
     data.headers = ['name', 'run_number', 'id', 'user', 'organization',
@@ -337,6 +331,7 @@ def workflow_status(ctx, user, organization, workflow, filter, output_format):
     default=default_organization,
     help='Organization whose resources will be used.')
 @click.option(
+    '-w',
     '--workflow',
     callback=workflow_uuid_or_name,
     help='Name or UUID of the workflow whose logs should be fetched. '
@@ -344,10 +339,9 @@ def workflow_status(ctx, user, organization, workflow, filter, output_format):
 @click.pass_context
 def workflow_logs(ctx, user, organization, workflow):
     """Get status of previously created analysis workflow."""
-    logging.debug('workflow.start')
-    logging.debug('user: {}'.format(user))
-    logging.debug('organization: {}'.format(organization))
-    logging.debug('workflow: {}'.format(workflow))
+    logging.debug('command: {}'.format(ctx.command_path.replace(" ", ".")))
+    for p in ctx.params:
+        logging.debug('{param}: {value}'.format(param=p, value=ctx.params[p]))
 
     workflow_name = workflow or os.environ.get('REANA_WORKON', None)
 

--- a/reana_client/cli/workflow.py
+++ b/reana_client/cli/workflow.py
@@ -216,7 +216,6 @@ def workflow_start(ctx, user, organization, workflow):
         logging.debug('{param}: {value}'.format(param=p, value=ctx.params[p]))
 
     logging.info('Workflow `{}` selected'.format(workflow))
-    click.echo('Workflow `{}` selected.'.format(workflow))
 
     try:
 
@@ -225,8 +224,7 @@ def workflow_start(ctx, user, organization, workflow):
                                                  organization,
                                                  workflow)
         click.echo(
-            click.style('Workflow `{}` has been started.'
-                        .format(response['workflow_id']),
+            click.style('{} has been started.'.format(workflow),
                         fg='green'))
 
     except Exception as e:

--- a/reana_client/errors.py
+++ b/reana_client/errors.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2017, 2018 CERN.
+# Copyright (C) 2018 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it under the
 # terms of the GNU General Public License as published by the Free Software
@@ -19,23 +19,9 @@
 # In applying this license, CERN does not waive the privileges and immunities
 # granted to it by virtue of its status as an Intergovernmental Organization or
 # submit itself to any jurisdiction.
-"""REANA client configuration."""
 
-import pkg_resources
+"""REANA-Client errors."""
 
-reana_yaml_default_file_path = './reana.yaml'  # e.g. `./.reana.yaml`
-"""REANA specification file default location."""
 
-reana_yaml_schema_file_path = pkg_resources.resource_filename(
-        __name__,
-        'schemas/reana_analysis_schema.json')
-"""REANA specification schema location."""
-
-default_user = '00000000-0000-0000-0000-000000000000'
-"""Default user to use when submitting workflows to Reana Server."""
-
-default_organization = 'default'
-"""Default organisation to use when submitting workflows to Reana Server."""
-
-default_download_path = './outputs/'
-"""Default path where files outputted by a workflow will be downloaded."""
+class FileUploadError(Exception):
+    """File upload didn't succeed."""

--- a/reana_client/utils.py
+++ b/reana_client/utils.py
@@ -23,6 +23,8 @@
 
 import json
 import logging
+import os
+import sys
 from uuid import UUID
 
 import click
@@ -183,3 +185,27 @@ def get_workflow_name_and_run_number(workflow_name):
         # Couldn't split. Probably not a dot-separated string.
         # Return the name given as parameter without a `run_number`.
         return workflow_name, ''
+
+
+def get_analysis_root():
+    """Return the current analysis root directory."""
+    reana_yaml = 'reana.yaml'
+    analysis_root = os.getcwd()
+
+    while True:
+        file_list = os.listdir(analysis_root)
+        parent_dir = os.path.dirname(analysis_root)
+        if reana_yaml in file_list:
+            break
+        else:
+            if analysis_root == parent_dir:
+                click.echo(click.style(
+                    'Not an analysis directory (or any of the parent'
+                    ' directories).\nPlease upload from inside'
+                    ' the directory containing the reana.yaml '
+                    'file of your analysis.', fg='red'))
+                sys.exit(1)
+            else:
+                analysis_root = parent_dir
+    analysis_root += '/'
+    return analysis_root


### PR DESCRIPTION
* Add support for specifying files that should be
  uploaded to workflow workspace by absolute paths (closes #67).

Signed-off-by: Harri Hirvonsalo <harri.hirvonsalo@cern.ch>