### PR TITLE
release: v0.2.0

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -5,5 +5,6 @@ The list of contributors in alphabetical order:
 
 - Anton Khodak <anton.khodak@ukr.net>
 - Diego Rodriguez <diego.rodriguez@cern.ch>
+- Dinos Kousidis <dinos.kousidis@cern.ch>
 - Harri Hirvonsalo <harri.hirvonsalo@cern.ch>
 - Tibor Simko <tibor.simko@cern.ch>

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,15 @@
 Changes
 =======
 
+Version 0.2.0 (2018-04-20)
+--------------------------
+
+- Adds support for Common Workflow Language workflows.
+- Adds support for persistent user-selected workflow names.
+- Enables file and directory input uploading using absolute paths.
+- Adds new ``status`` command to display the current status of the client.
+- Reduces verbosity level for commands and improves error messages.
+
 Version 0.1.0 (2018-01-30)
 --------------------------
 

--- a/reana_client/version.py
+++ b/reana_client/version.py
@@ -28,4 +28,4 @@ This file is imported by ``reana_client.__init__`` and parsed by
 
 from __future__ import absolute_import, print_function
 
-__version__ = "0.1.0.dev20180201"
+__version__ = "0.2.0"


### PR DESCRIPTION
(To be merged after https://github.com/reanahub/reana-client/pull/79)

Signed-off-by: Dinos Kousidis <konstantinos.kousidis@cern.ch>