### PR TITLE
cli: addition of parameters in workflow_start()

### DIFF
--- a/reana_client/api/client.py
+++ b/reana_client/api/client.py
@@ -162,14 +162,15 @@ class Client(object):
         except Exception as e:
             raise e
 
-    def start_workflow(self, workflow, access_token):
+    def start_workflow(self, workflow, access_token, parameters):
         """Start a workflow."""
         try:
             (response,
              http_response) = self._client.api.set_workflow_status(
                  workflow_id_or_name=workflow,
                  status='start',
-                 access_token=access_token).result()
+                 access_token=access_token,
+                 parameters=parameters).result()
             if http_response.status_code == 200:
                 return response
             else:

--- a/reana_client/cli/workflow.py
+++ b/reana_client/cli/workflow.py
@@ -235,8 +235,12 @@ def workflow_create(ctx, file, name, skip_validation, access_token):
     '--access-token',
     default=os.environ.get('REANA_ACCESS_TOKEN', None),
     help='Access token of the current user.')
+@click.argument(
+    'parameters',
+    nargs=-1,
+)
 @click.pass_context
-def workflow_start(ctx, workflow, access_token):
+def workflow_start(ctx, workflow, access_token, parameters):
     """Start previously created workflow."""
     logging.debug('command: {}'.format(ctx.command_path.replace(" ", ".")))
     for p in ctx.params:
@@ -248,11 +252,15 @@ def workflow_start(ctx, workflow, access_token):
                         fg='red'), err=True)
         sys.exit(1)
 
+    parsed_parameters = {'parameters':
+                         dict(p.split('=') for p in parameters)}
+
     if workflow:
         try:
             logging.info('Connecting to {0}'.format(ctx.obj.client.server_url))
             response = ctx.obj.client.start_workflow(workflow,
-                                                     access_token)
+                                                     access_token,
+                                                     parsed_parameters)
             click.echo(
                 click.style('{} has been started.'.format(workflow),
                             fg='green'))

--- a/reana_client/openapi_connections/reana_server.json
+++ b/reana_client/openapi_connections/reana_server.json
@@ -585,13 +585,10 @@
           },
           {
             "description": "Required. New workflow status.",
-            "in": "body",
+            "in": "query",
             "name": "status",
             "required": true,
-            "schema": {
-              "description": "Required. New status.",
-              "type": "string"
-            }
+            "type": "string"
           },
           {
             "description": "Required. The API access_token of workflow owner.",
@@ -599,6 +596,15 @@
             "name": "access_token",
             "required": true,
             "type": "string"
+          },
+          {
+            "description": "Optional. Extra parameters for workflow status.",
+            "in": "body",
+            "name": "parameters",
+            "required": false,
+            "schema": {
+              "type": "object"
+            }
           }
         ],
         "produces": [


### PR DESCRIPTION
* ADD arbitrary number of parameters in workflow_start().

* Updates the reana-server openapi spec with parameters in
  set_workflow_status, and the status passed in the query instead of
  the request body.

Connects https://github.com/reanahub/reana-client/issues/21
Closes https://github.com/reanahub/reana-client/issues/143

Signed-off-by: Dinos Kousidis <dinos.kousidis@cern.ch>