### PR TITLE
installation: more version limits

### DIFF
--- a/reana_client/version.py
+++ b/reana_client/version.py
@@ -28,4 +28,4 @@ This file is imported by ``reana_client.__init__`` and parsed by
 
 from __future__ import absolute_import, print_function
 
-__version__ = "0.3.0"
+__version__ = "0.3.1.dev20180905"

--- a/setup.py
+++ b/setup.py
@@ -65,14 +65,14 @@ setup_requires = [
 ]
 
 install_requires = [
-    'bravado>=9.0.6',
-    'click>=6.7',
+    'bravado>=9.0.6,<10.2',
+    'click>=6.7,<6.8',
     'cwltool==1.0.20180326152342',
     'pyOpenSSL==17.3.0',  # FIXME remove once yadage-schemas solves deps.
     'reana-commons>=0.3.1,<0.4',
     'rfc3987==1.3.7',  # FIXME remove once yadage-schemas solves deps.
     'strict-rfc3339==0.7',  # FIXME remove once yadage-schemas solves deps.
-    'tablib>=0.12.1',
+    'tablib>=0.12.1,<0.13',
     'webcolors==1.7',  # FIXME remove once yadage-schemas solves deps.
     'yadage-schemas==0.7.16',
 ]


### PR DESCRIPTION
* Introduces more upper boundary limits for dependencies to make sure all the
  client components are installable from PyPI in the future.
  (addresses reanahub/reana#80)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>