### PR TITLE
cli: download all outputs

### DIFF
--- a/docs/userguide.rst
+++ b/docs/userguide.rst
@@ -79,6 +79,15 @@ Uploading files or directories to an analysis workspace is simple as:
    File file2 was successfully uploaded.
    File directory1/file3 was successfully uploaded.
 
+If you want to upload all input files defined in the reana.yaml of the analysis,
+you can just run:
+
+.. code-block:: console
+
+   $ reana-client upload
+   File file1 was successfully uploaded.
+   File file2 was successfully uploaded.
+
 Directory structures are maintained, i.e.
 directory1 exists in the workspace.
 
@@ -86,6 +95,25 @@ Note that symbolic links are resolved at the moment of upload
 so that a hard copy of the link target is uploaded to the cloud
 storage workspace. The link is not maintained throughout the 
 workflow execution.
+
+Downloading outputs
+~~~~~~~~~~~~~~~~~~~
+
+Downloading files from an analysis workspace works in the same way:
+
+.. code-block:: console
+
+   $ reana-client download result.png
+   File plot.png downloaded to /myfirstanalysis.
+
+In the same way you can download all outputs defined in the reana.yaml
+file of the analysis, by just running:
+
+.. code-block:: console
+
+   $ reana-client download
+
+Note that downloading directories is not yet supported.
 
 Examples
 --------

--- a/reana_client/cli/files.py
+++ b/reana_client/cli/files.py
@@ -128,10 +128,13 @@ def get_files(ctx, workflow, _filter,
 
 @click.command(
     'download',
-    help='Download one or more files.')
+    help='Download all output files declared in the reana.yaml'
+         'specification or download files listed as '
+         'FILE command-line arguments. Note that downloading directories'
+         ' is not yet supported.')
 @click.argument(
     'filenames',
-    metavar='FILE',
+    metavar='FILES',
     nargs=-1)
 @click.option(
     '-w',
@@ -214,12 +217,13 @@ def download_files(ctx, workflow, filenames, output_directory, access_token):
 
 @click.command(
     'upload',
-    help='Upload files and directories to the workflow workspace.\n'
-         'If a symbolic link is provided, it is resolved and\n'
-         'a hard copy is uploaded.')
+    help='Upload all input sources declared in the reana.yaml'
+         'specification or upload files and directories listed as '
+         'SOURCE command-line arguments. If a symbolic link is provided,'
+         ' it is resolved and a hard copy is uploaded.')
 @click.argument(
     'filenames',
-    metavar='SOURCE',
+    metavar='SOURCES',
     type=click.Path(exists=True, resolve_path=True),
     nargs=-1)
 @click.option(


### PR DESCRIPTION
* Modifies the cli `reana-client download` command to parse the
  reana.yaml and download all outputs listed there.

Closes #173 

Signed-off-by: Dinos Kousidis <dinos.kousidis@cern.ch>