### PR TITLE
cli: workflow logs refactoring

### DIFF
--- a/reana_client/cli/utils.py
+++ b/reana_client/cli/utils.py
@@ -14,7 +14,7 @@ import click
 
 
 def add_access_token_options(func):
-    """Adds access token related options to click commands."""
+    """Add access token related options to click commands."""
     @click.option('-at', '--access-token',
                   default=os.getenv('REANA_ACCESS_TOKEN', None),
                   help='Access token of the current user.')

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ install_requires = [
     'click>=7,<8',
     'cwltool==1.0.20181118133959',
     'pyOpenSSL==17.5.0',  # FIXME remove once yadage-schemas solves deps.
-    'reana-commons>=0.5.0.dev20190116,<0.6.0',
+    'reana-commons>=0.5.0.dev20190125,<0.6.0',
     'rfc3987==1.3.7',  # FIXME remove once yadage-schemas solves deps.
     'strict-rfc3339==0.7',  # FIXME remove once yadage-schemas solves deps.
     'tablib>=0.12.1,<0.13',


### PR DESCRIPTION
* Refactors get workflow logs to RWC response, which includes the
  logs from the jobs of the workflow.

Closes https://github.com/reanahub/reana-client/issues/218, https://github.com/reanahub/reana-client/issues/217

Signed-off-by: Dinos Kousidis <dinos.kousidis@cern.ch>