### PR TITLE
cli: add follow flag to workflow execution

### DIFF
--- a/reana_client/config.py
+++ b/reana_client/config.py
@@ -29,5 +29,8 @@ ERROR_MESSAGES = {
         ' REANA_ACCESS_TOKEN environment variable.'
 }
 
+TIMECHECK = 5
+"""Time between workflow status check."""
+
 WORKFLOW_ENGINES = ['serial', 'cwl', 'yadage']
 """Supported workflow engines."""


### PR DESCRIPTION
Closes #295

Adds a flag the start and run workflow commands to follow the
workflow execution until termination.

Signed-off-by: leticia <leticia.farias.wanderley@cern.ch>