### PR TITLE
cli: secrets cli refactor

### DIFF
--- a/docs/userguide.rst
+++ b/docs/userguide.rst
@@ -141,28 +141,28 @@ the ``secrets-add`` command:
 .. code-block:: console
 
    $ # You can upload secrets from literal strings:
-   $ reana-client secrets-add --from-literal HTCONDORCERN_USERNAME=johndoe
-                              --from-literal HTCONDORCERN_KEYTAB=.keytab
+   $ reana-client secrets-add --env HTCONDORCERN_USERNAME=johndoe
+                              --env HTCONDORCERN_KEYTAB=.keytab
    Secrets HTCONDORCERN_USERNAME, HTCONDORCERN_KEYTAB were successfully uploaded.
 
    $ # ...and from files:
-   $ reana-client secrets-add --from-file ~/.keytab
+   $ reana-client secrets-add --file ~/.keytab
    Secrets .keytab were successfully uploaded.
 
    $ # ...you can also combine two options in one command:
-   $ reana-client secrets-add --from-literal HTCONDORCERN_USERNAME=johndoe
-                              --from-literal HTCONDORCERN_KEYTAB=.keytab
-                              --from-file ~/.keytab
+   $ reana-client secrets-add --env HTCONDORCERN_USERNAME=johndoe
+                              --env HTCONDORCERN_KEYTAB=.keytab
+                              --file ~/.keytab
    Secrets .keytab, HTCONDORCERN_USERNAME, HTCONDORCERN_KEYTAB were successfully uploaded.
 
    $ # Trying to add a secret that is already added
    $ # will result in a warning and no action will be taken:
-   $ reana-client secrets-add --from-literal HTCONDORCERN_USERNAME=johndoe
+   $ reana-client secrets-add --env HTCONDORCERN_USERNAME=johndoe
    One of the secrets already exists. No secrets were added.
 
    $ # If you are sure that you want to overwrite it you can use
    $ # the ``--overwrite`` option:
-   $ reana-client secrets-add --from-literal HTCONDORCERN_USERNAME=janedoe
+   $ reana-client secrets-add --env HTCONDORCERN_USERNAME=janedoe
                               --overwrite
    Secrets USERNAME were successfully uploaded.
    $ # Note that the ``--overwrite`` option will aply to

--- a/reana_client/utils.py
+++ b/reana_client/utils.py
@@ -311,9 +311,10 @@ def parse_secret_from_path(path):
      via http request.
     """
     try:
-        with open(path, 'rb') as file:
+        with open(os.path.expanduser(path), 'rb') as file:
+            file_name = os.path.basename(path)
             secret = {
-                file.name: {
+                file_name: {
                     'value': base64.b64encode(
                         file.read()).decode('utf-8'),
                     'type': 'file'

--- a/tests/test_cli_secrets.py
+++ b/tests/test_cli_secrets.py
@@ -90,8 +90,8 @@ def test_secrets_add(secret):
                 result = runner.invoke(
                     cli, ['secrets-add',
                           '-t', reana_token,
-                          '--from-file', secret_file,
-                          '--from-literal', secret]
+                          '--file', secret_file,
+                          '--env', secret]
                 )
                 assert result.exit_code == 0
                 assert message in result.output
@@ -109,7 +109,7 @@ def test_secrets_add_wrong_format(secret):
 
     result = runner.invoke(
         cli, ['secrets-add', '-t', reana_token,
-              '--from-literal', secret]
+              '--env', secret]
     )
     assert result.exit_code == 1
     assert message in result.output
@@ -136,7 +136,7 @@ def test_secrets_add_already_exist():
                 result = runner.invoke(
                     cli, ['secrets-add',
                           '-t', reana_token,
-                          '--from-literal', 'USER=reanauser']
+                          '--env', 'USER=reanauser']
                 )
                 assert message in result.output
                 assert result.exit_code == 1


### PR DESCRIPTION
* Change syntax for file and env types (Closes #306)

* Introduce NotRequiredIf functionality for click options (Closes #288)

* Change type of  argument to click.Path for native path support (Closes #294)

* Limit k8s secret name to just basename- it used to fail
because of forbiden characters (Closes #305)

Signed-off-by: Jan Okraska <jan.okraska@cern.ch>