### PR TITLE
cwltool: 1.0.20191022103248

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,13 +31,16 @@ matrix:
       env: REQUIREMENTS=release EXTRAS=all
     - python: 3.7
       env: REQUIREMENTS=devel EXTRAS=all
-      dist: xenial
     - python: 3.7
       env: REQUIREMENTS=lowest EXTRAS=all
-      dist: xenial
     - python: 3.7
       env: REQUIREMENTS=release EXTRAS=all
-      dist: xenial
+    - python: 3.8
+      env: REQUIREMENTS=devel EXTRAS=all
+    - python: 3.8
+      env: REQUIREMENTS=lowest EXTRAS=all
+    - python: 3.8
+      env: REQUIREMENTS=release EXTRAS=all
 
 before_install:
   - travis_retry pip install --upgrade pip setuptools py

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ install_requires = [
     'typing>=3.7.4 ; python_version=="2.7"',  # workaround for CWL deps
     'click>=7',
     'cryptography>=2.7',
-    'cwltool==1.0.20190815141648',
+    'cwltool==1.0.20191022103248',
     'pyOpenSSL>=19.0.0',  # FIXME remove once yadage-schemas solves deps.
     'jsonpointer>=2.0',
     'reana-commons>=0.6.0.dev20190604,<0.7.0',
@@ -100,6 +100,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python',
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',


### PR DESCRIPTION
* Upgrades version of `cwltool` to 1.0.20191022103248 which fixes
  installation troubles on Python-3.8 systems.
  (addresses reanahub/reana-client#329)

Signed-off-by: Tibor Šimko <tibor.simko@cern.ch>