### PR TITLE
installation: PyYAML version boundaries

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ setup_requires = [
 ]
 
 install_requires = [
+    'PyYAML>=5.1',
     'typing>=3.7.4 ; python_version=="2.7"',  # workaround for CWL deps
     'click>=7',
     'cryptography>=2.7',


### PR DESCRIPTION
* Specifies minimal PyYAML version to 5.1 and above. This fixes a
  problem with file upload using Python-2.7.  (closes #301)

Signed-off-by: Tibor Šimko <tibor.simko@cern.ch>