### PR TITLE
cli: optimize reana-client

### DIFF
--- a/reana_client/api/client.py
+++ b/reana_client/api/client.py
@@ -252,12 +252,12 @@ def upload_file(workflow_id, file_, file_name, access_token):
     :param file_name: name of a file that will be uploaded.
     :param access_token: access token of the current user.
     """
+    from reana_client.cli import get_api_url
     try:
-        api_url = current_rs_api_client.swagger_spec.__dict__.get('api_url')
         endpoint = \
             current_rs_api_client.api.upload_file.operation.path_name.format(
                 workflow_id_or_name=workflow_id)
-        http_response = requests.post(urljoin(api_url, endpoint),
+        http_response = requests.post(urljoin(get_api_url(), endpoint),
                                       data=file_,
                                       params={'file_name': file_name,
                                               'access_token': access_token},
@@ -269,7 +269,7 @@ def upload_file(workflow_id, file_, file_name, access_token):
         logging.debug(
             'File could not be uploaded.', exc_info=True)
         raise Exception(
-            'Could not connect to the server {}'.format(api_url))
+            'Could not connect to the server {}'.format(get_api_url()))
     except requests.exceptions.HTTPError as e:
         logging.debug(
             'The server responded with an HTTP error code.', exc_info=True)
@@ -326,7 +326,7 @@ def download_file(workflow_id, file_name, access_token):
     """
     try:
         logging.getLogger("urllib3").setLevel(logging.CRITICAL)
-        (_, http_response) = current_rs_api_client.api.download_file(
+        _, http_response = current_rs_api_client.api.download_file(
             workflow_id_or_name=workflow_id,
             file_name=file_name,
             access_token=access_token).result()

--- a/reana_client/api/client.py
+++ b/reana_client/api/client.py
@@ -252,7 +252,7 @@ def upload_file(workflow_id, file_, file_name, access_token):
     :param file_name: name of a file that will be uploaded.
     :param access_token: access token of the current user.
     """
-    from reana_client.cli import get_api_url
+    from reana_client.utils import get_api_url
     try:
         endpoint = \
             current_rs_api_client.api.upload_file.operation.path_name.format(

--- a/reana_client/cli/__init__.py
+++ b/reana_client/cli/__init__.py
@@ -71,6 +71,11 @@ class ReanaCLI(click.Group):
                     formatter.write_dl(item['rows'])
 
 
+def get_api_url():
+    """Obtain REANA server API URL."""
+    return os.environ.get('REANA_SERVER_URL')
+
+
 @click.command(cls=ReanaCLI)
 @click.option(
     '--loglevel',

--- a/reana_client/cli/__init__.py
+++ b/reana_client/cli/__init__.py
@@ -11,7 +11,7 @@ import os
 import sys
 
 import click
-import urllib3
+from urllib3 import disable_warnings
 
 from reana_client.cli import workflow, files, ping, secrets
 
@@ -42,7 +42,7 @@ class ReanaCLI(click.Group):
 
     def __init__(self, name=None, commands=None, **attrs):
         """Initialize REANA client commands."""
-        urllib3.disable_warnings()
+        disable_warnings()
         click.Group.__init__(self, name, **attrs)
         for group in ReanaCLI.cmd_groups:
             for cmd in group.commands.items():
@@ -69,11 +69,6 @@ class ReanaCLI(click.Group):
             for item in rows:
                 with formatter.section(item['group_help']):
                     formatter.write_dl(item['rows'])
-
-
-def get_api_url():
-    """Obtain REANA server API URL."""
-    return os.environ.get('REANA_SERVER_URL')
 
 
 @click.command(cls=ReanaCLI)

--- a/reana_client/cli/cwl_runner.py
+++ b/reana_client/cli/cwl_runner.py
@@ -72,6 +72,7 @@ def get_file_dependencies_obj(cwl_obj, basedir):
 def cwl_runner(ctx, quiet, outdir, basedir, processfile, jobfile,
                access_token):
     """Run CWL files in a standard format <workflow.cwl> <job.json>."""
+    from reana_client.api import get_api_url
     logging.basicConfig(
         format='[%(levelname)s] %(message)s',
         stream=sys.stderr,
@@ -106,8 +107,7 @@ def cwl_runner(ctx, quiet, outdir, basedir, processfile, jobfile,
         reana_spec['workflow']['spec'] = replace_location_in_cwl_spec(
             reana_spec['workflow']['spec'])
 
-        logging.info('Connecting to {0}'.format(
-            current_rs_api_client.swagger_spec.api_url))
+        logging.info('Connecting to {0}'.format(get_api_url()))
         response = create_workflow(reana_spec, 'cwl-test', access_token)
         logging.error(response)
         workflow_name = response['workflow_name']

--- a/reana_client/cli/cwl_runner.py
+++ b/reana_client/cli/cwl_runner.py
@@ -24,9 +24,6 @@ from cwltool.load_tool import fetch_document
 from cwltool.main import printdeps
 from cwltool.workflow import findfiles
 
-from reana_client.api.client import (create_workflow, current_rs_api_client,
-                                     get_workflow_logs, start_workflow,
-                                     upload_file)
 from reana_client.cli.utils import add_access_token_options
 from reana_client.config import default_user
 from reana_client.utils import load_workflow_spec
@@ -72,7 +69,10 @@ def get_file_dependencies_obj(cwl_obj, basedir):
 def cwl_runner(ctx, quiet, outdir, basedir, processfile, jobfile,
                access_token):
     """Run CWL files in a standard format <workflow.cwl> <job.json>."""
-    from reana_client.api import get_api_url
+    from reana_client.utils import get_api_url
+    from reana_client.api.client import (create_workflow, get_workflow_logs,
+                                         start_workflow, upload_file)
+
     logging.basicConfig(
         format='[%(levelname)s] %(message)s',
         stream=sys.stderr,

--- a/reana_client/cli/files.py
+++ b/reana_client/cli/files.py
@@ -15,7 +15,6 @@ import traceback
 
 import click
 
-import tablib
 from reana_client.api.client import (current_rs_api_client, delete_file,
                                      download_file, get_workflow_disk_usage,
                                      get_workflow_status, list_files, mv_files,
@@ -77,6 +76,7 @@ def get_files(ctx, workflow, _filter,
     Examples: \n
     \t $ reana-client ls --workflow myanalysis.42
     """
+    import tablib
     logging.debug('command: {}'.format(ctx.command_path.replace(" ", ".")))
     for p in ctx.params:
         logging.debug('{param}: {value}'.format(param=p, value=ctx.params[p]))

--- a/reana_client/cli/files.py
+++ b/reana_client/cli/files.py
@@ -15,10 +15,6 @@ import traceback
 
 import click
 
-from reana_client.api.client import (current_rs_api_client, delete_file,
-                                     download_file, get_workflow_disk_usage,
-                                     get_workflow_status, list_files, mv_files,
-                                     upload_to_server)
 from reana_client.api.utils import get_path_from_operation_id
 from reana_client.cli.utils import (add_access_token_options,
                                     add_workflow_option, check_connection,
@@ -77,6 +73,8 @@ def get_files(ctx, workflow, _filter,
     \t $ reana-client ls --workflow myanalysis.42
     """
     import tablib
+    from reana_client.api.client import current_rs_api_client, list_files
+
     logging.debug('command: {}'.format(ctx.command_path.replace(" ", ".")))
     for p in ctx.params:
         logging.debug('{param}: {value}'.format(param=p, value=ctx.params[p]))
@@ -161,6 +159,8 @@ def download_files(ctx, workflow, filenames,
     \t $ reana-client download # download all output files \n
     \t $ reana-client download mydata.tmp outputs/myplot.png
     """
+    from reana_client.api.client import download_file
+
     logging.debug('command: {}'.format(ctx.command_path.replace(" ", ".")))
     for p in ctx.params:
         logging.debug('{param}: {value}'.format(param=p, value=ctx.params[p]))
@@ -230,6 +230,8 @@ def upload_files(ctx, workflow, filenames, access_token):  # noqa: D301
     \t $ reana-client upload -w myanalysis.42 \n
     \t $ reana-client upload -w myanalysis.42 code/mycode.py
     """
+    from reana_client.api.client import upload_to_server
+
     logging.debug('command: {}'.format(ctx.command_path.replace(" ", ".")))
     for p in ctx.params:
         logging.debug('{param}: {value}'.format(param=p, value=ctx.params[p]))
@@ -319,6 +321,8 @@ def delete_files(ctx, workflow, filenames, access_token):  # noqa: D301
     \t $ reana-client rm -w myanalysis.42 data/mydata.csv \n
     \t $ reana-client rm -w myanalysis.42 'code/\*'
     """
+    from reana_client.api.client import delete_file
+
     logging.debug('command: {}'.format(ctx.command_path.replace(" ", ".")))
     for p in ctx.params:
         logging.debug('{param}: {value}'.format(param=p, value=ctx.params[p]))
@@ -374,6 +378,9 @@ def move_files(ctx, source, target, workflow, access_token):  # noqa: D301
     Examples:\n
     \t $ reana-client mv data/input.txt input/input.txt
     """
+    from reana_client.api.client import (get_workflow_status, list_files,
+                                         mv_files)
+
     logging.debug('command: {}'.format(ctx.command_path.replace(" ", ".")))
     for p in ctx.params:
         logging.debug('{param}: {value}'.format(param=p, value=ctx.params[p]))
@@ -441,6 +448,8 @@ def workflow_disk_usage(ctx, workflow, access_token, summarize, block_size):  # 
     \t $ reana-client du -w myanalysis.42 -s \n
     \t $ reana-client du -w myanalysis.42 --bytes
     """
+    from reana_client.api.client import get_workflow_disk_usage
+
     logging.debug('command: {}'.format(ctx.command_path.replace(" ", ".")))
     for p in ctx.params:
         logging.debug('{param}: {value}'.format(param=p, value=ctx.params[p]))

--- a/reana_client/cli/ping.py
+++ b/reana_client/cli/ping.py
@@ -11,7 +11,6 @@ import logging
 import traceback
 
 import click
-from reana_client.api.client import ping as rs_ping
 from reana_client.cli.utils import check_connection
 from reana_client.version import __version__
 
@@ -34,7 +33,8 @@ def ping(ctx):  # noqa: D301
     \t $ reana-client ping
     """
     try:
-        from reana_client.cli import get_api_url
+        from reana_client.api.client import ping as rs_ping
+        from reana_client.utils import get_api_url
         logging.info('Connecting to {0}'.format(get_api_url()))
         response = rs_ping()
         click.echo(click.style('Connected to {0} - Server is running.'

--- a/reana_client/cli/ping.py
+++ b/reana_client/cli/ping.py
@@ -11,7 +11,6 @@ import logging
 import traceback
 
 import click
-from reana_client.api.client import current_rs_api_client
 from reana_client.api.client import ping as rs_ping
 from reana_client.cli.utils import check_connection
 from reana_client.version import __version__
@@ -35,21 +34,19 @@ def ping(ctx):  # noqa: D301
     \t $ reana-client ping
     """
     try:
-        logging.info('Connecting to {0}'.format(
-            current_rs_api_client.swagger_spec.api_url))
+        from reana_client.cli import get_api_url
+        logging.info('Connecting to {0}'.format(get_api_url()))
         response = rs_ping()
-        click.echo(click.style('Connected to {0} - Server is running.'.format(
-            current_rs_api_client.swagger_spec.api_url), fg='green'))
+        click.echo(click.style('Connected to {0} - Server is running.'
+                               .format(get_api_url()), fg='green'))
         logging.debug('Server response:\n{}'.format(response))
 
     except Exception as e:
         logging.debug(traceback.format_exc())
         logging.debug(str(e))
-        click.echo(click.style(
-            'Could not connect to the selected '
-            'REANA cluster server at {0}.'.format(
-                current_rs_api_client.swagger_spec.api_url),
-            fg='red'), err=True)
+        error_msg = ('Could not connect to the selected REANA cluster'
+                     'server at {0}.'.format(get_api_url()))
+        click.echo(click.style(error_msg, fg='red'), err=True)
 
 
 @configuration_group.command('version')

--- a/reana_client/cli/secrets.py
+++ b/reana_client/cli/secrets.py
@@ -11,8 +11,6 @@ import sys
 import traceback
 
 import click
-from reana_client.api.client import add_secrets, delete_secrets, \
-    list_secrets, current_rs_api_client
 from reana_client.cli.utils import (add_access_token_options, check_connection,
                                     NotRequiredIf)
 from reana_client.config import ERROR_MESSAGES
@@ -65,6 +63,8 @@ def secrets_add(env, file, overwrite, access_token):  # noqa: D301
     \t                            --env PASSWORD=password \n
     \t                            --file ~/.keytab
     """
+    from reana_client.api.client import add_secrets
+
     secrets_ = {}
     for literal in env:
         secret = parse_secret_from_literal(literal)
@@ -108,6 +108,8 @@ def secrets_delete(secrets, access_token):  # noqa: D301
      Examples: \n
     \t $ reana-client secrets-delete PASSWORD
     """
+    from reana_client.api.client import delete_secrets
+
     try:
         deleted_secrets = delete_secrets(secrets, access_token)
     except REANASecretDoesNotExist as e:
@@ -142,6 +144,8 @@ def secrets_list(access_token):  # noqa: D301
     Examples: \n
     \t $ reana-client secrets-list
     """
+    from reana_client.api.client import list_secrets
+
     try:
         secrets = list_secrets(access_token)
         headers = ['name', 'type']

--- a/reana_client/cli/utils.py
+++ b/reana_client/cli/utils.py
@@ -15,7 +15,6 @@ import sys
 
 import click
 
-from reana_client.api.client import current_rs_api_client
 from reana_client.utils import workflow_uuid_or_name
 from reana_client.config import ERROR_MESSAGES
 from reana_commons.errors import MissingAPIClientConfiguration
@@ -48,13 +47,12 @@ def check_connection(func):
     """Check if connected to any REANA cluster."""
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
-        try:
-            _url = current_rs_api_client.swagger_spec.api_url
-        except MissingAPIClientConfiguration as e:
+        from reana_client.cli import get_api_url
+        api_url = get_api_url()
+        if not api_url:
             click.secho(
                 'REANA client is not connected to any REANA cluster.',
-                fg='red', err=True
-            )
+                fg='red', err=True)
             sys.exit(1)
         return func(*args, **kwargs)
     return wrapper

--- a/reana_client/cli/utils.py
+++ b/reana_client/cli/utils.py
@@ -47,7 +47,7 @@ def check_connection(func):
     """Check if connected to any REANA cluster."""
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
-        from reana_client.cli import get_api_url
+        from reana_client.utils import get_api_url
         api_url = get_api_url()
         if not api_url:
             click.secho(

--- a/reana_client/cli/workflow.py
+++ b/reana_client/cli/workflow.py
@@ -15,7 +15,6 @@ import time
 import traceback
 
 import click
-import tablib
 from jsonschema.exceptions import ValidationError
 from reana_client.api.client import (close_interactive_session,
                                      create_workflow, current_rs_api_client,
@@ -118,6 +117,7 @@ def workflow_workflows(ctx, sessions, _filter, output_format, access_token,
     \t $ reana-client list --sessions \n
     \t $ reana-client list --verbose --bytes
     """
+    import tablib
     logging.debug('command: {}'.format(ctx.command_path.replace(" ", ".")))
     for p in ctx.params:
         logging.debug('{param}: {value}'.format(param=p, value=ctx.params[p]))
@@ -222,6 +222,7 @@ def workflow_create(ctx, file, name,
     \t $ reana-client create -w myanalysis\n
     \t $ reana-client create -w myanalysis -f myreana.yaml\n
     """
+    from reana_client.cli import get_api_url
     logging.debug('command: {}'.format(ctx.command_path.replace(" ", ".")))
     for p in ctx.params:
         logging.debug('{param}: {value}'.format(param=p, value=ctx.params[p]))
@@ -236,8 +237,7 @@ def workflow_create(ctx, file, name,
     try:
         reana_specification = load_reana_spec(click.format_filename(file),
                                               skip_validation)
-        logging.info('Connecting to {0}'.format(
-            current_rs_api_client.swagger_spec.api_url))
+        logging.info('Connecting to {0}'.format(get_api_url()))
         response = create_workflow(reana_specification,
                                    name,
                                    access_token)
@@ -306,6 +306,7 @@ def workflow_start(ctx, workflow, access_token,
     \t $ reana-client start -w myanalysis.42 -p sleeptime=10 -p myparam=4 \n
     \t $ reana-client start -w myanalysis.42 -p myparam1=myvalue1 -o CACHE=off
     """
+    from reana_client.cli import get_api_url
     logging.debug('command: {}'.format(ctx.command_path.replace(" ", ".")))
     for p in ctx.params:
         logging.debug('{param}: {value}'.format(param=p, value=ctx.params[p]))
@@ -335,8 +336,7 @@ def workflow_start(ctx, workflow, access_token,
                                 '{0} \n{1}'.format(parameters, str(e))),
                     err=True)
         try:
-            logging.info('Connecting to {0}'.format(
-                current_rs_api_client.swagger_spec.api_url))
+            logging.info('Connecting to {0}'.format(get_api_url()))
             response = start_workflow(workflow,
                                       access_token,
                                       parsed_parameters)
@@ -411,6 +411,8 @@ def workflow_status(ctx, workflow, _filter, output_format,
     \t $ reana-client status -w myanalysis.42 \n
     \t $ reana-client status -w myanalysis.42 -v --json
     """
+    import tablib
+
     def render_progress(finished_jobs, total_jobs):
         if total_jobs:
             return '{0}/{1}'.format(finished_jobs, total_jobs)
@@ -777,14 +779,14 @@ def workflow_delete(ctx, workflow, all_runs, workspace,
     \t $ reana-client delete -w myanalysis.42 \n
     \t $ reana-client delete -w myanalysis.42 --include-records
     """
+    from reana_client.cli import get_api_url
     logging.debug('command: {}'.format(ctx.command_path.replace(" ", ".")))
     for p in ctx.params:
         logging.debug('{param}: {value}'.format(param=p, value=ctx.params[p]))
 
     if workflow:
         try:
-            logging.info('Connecting to {0}'.format(
-                current_rs_api_client.swagger_spec.api_url))
+            logging.info('Connecting to {0}'.format(get_api_url()))
             response = delete_workflow(workflow,
                                        all_runs,
                                        hard_delete,

--- a/reana_client/utils.py
+++ b/reana_client/utils.py
@@ -351,3 +351,8 @@ def parse_secret_from_path(path):
                 .format(path),
                 fg='red'),
             err=True)
+
+
+def get_api_url():
+    """Obtain REANA server API URL."""
+    return os.environ.get('REANA_SERVER_URL')

--- a/tests/test_cli_workflows.py
+++ b/tests/test_cli_workflows.py
@@ -245,15 +245,14 @@ def test_create_workflow_from_json(create_yaml_workflow_schema):
                 "reana_client.api.client.current_rs_api_client",
                 make_mock_api_client('reana-server')(mock_response,
                                                      mock_http_response)):
-                result = create_workflow_from_json(
-                    workflow_json=workflow_json['workflow'],
-                    name=response['workflow_name'],
-                    access_token=reana_token,
-                    parameters=workflow_json['inputs'],
-                    workflow_engine='serial'
-                )
-                assert response['workflow_name'] == result['workflow_name']
-                assert response['message'] == result['message']
+            result = create_workflow_from_json(
+                workflow_json=workflow_json['workflow'],
+                name=response['workflow_name'],
+                access_token=reana_token,
+                parameters=workflow_json['inputs'],
+                workflow_engine='serial')
+            assert response['workflow_name'] == result['workflow_name']
+            assert response['message'] == result['message']
 
 
 @pytest.mark.parametrize("status", [


### PR DESCRIPTION
closes #354 

Optimizations:
* `ping`: ~2.2s → ~0.8s
* `--help`: ~0.6s → ~0.3s
* `version`: ~0.6s → ~0.3s
* `create`: ~2s → ~1.2s
* `start`: ~2.4s → ~1.5s
* `status`: ~1.6s → ~1.2s
* `run`: ~7s → ~3.9s (reana-demo-worldpopulation)
* `list`: ~1.6s → ~1.2s
* `diff`: ~1.6s → ~1s
* `logs`: ~1.6s → ~1s
* `stop`: ~1s → ~0.4s
* `upload`: ~2.3s → ~1.2s
* `download`: ~1.8s → ~1.1s
* `du`: ~1.5s → ~0.9s
* `ls`: ~2s → ~1.6s
* `mv`: ~2.9s → ~2.3s
* `rm`: ~1.6s → ~1s
