### PR TITLE
validate: enrich yadage validation output error

### DIFF
--- a/reana_client/utils.py
+++ b/reana_client/utils.py
@@ -64,8 +64,13 @@ def yadage_load(workflow_file, toplevel='.'):
         'schemadir': schemadir,
     }
 
-    return yadageschemas.load(spec=workflow_file, specopts=specopts,
-                              validopts=validopts, validate=True)
+    try:
+        return yadageschemas.load(spec=workflow_file, specopts=specopts,
+                                  validopts=validopts, validate=True)
+
+    except ValidationError as e:
+        e.message = str(e)
+        raise e
 
 
 def cwl_load(workflow_file):


### PR DESCRIPTION
closes #387

**Output:**
```console
$ reana-client validate -f reana-yadage.yaml                                        
/Users/marco/code/reanahub/reana-demo-root6-roofit/reana-yadage.yaml is not a valid REANA specification:
{'scheduler_type': 'singlestep-stage', 'parameters': [{'key': 'events', 'value': {'step': 'init', 'output': 'events', 'expression_type': 'stage-output-selector'}}, {'key': 'gendata', 'value': {'step': 'init', 'output': 'gendata', 'expression_type': 'stage-output-selector'}}, {'key': 'outfilename', 'value': '{workdir}/data.root'}], 'step': {'process': {'process_type': 'interpolated-script-cmd', 'script': 'root -b -q \'{gendata}({events},"{outfilename}")\'', 'interpreter': 'sh'}, 'publisher': {'publisher_type': 'frompar-pub', 'outputmap': {'data': 'outfilename'}}, 'xxxenvironment': {'environment_type': 'docker-encapsulated', 'image': 'reanahub/reana-env-root6', 'imagetag': '6.18.04'}}} is not valid under any of the given schemas

Failed validating 'oneOf' in schema['properties']['stages']['items']['properties']['scheduler']:
    {'oneOf': [{'$ref': 'scheduler/singlestep-stage-schema.json#'},
               {'$ref': 'scheduler/multistep-stage-schema.json#'},
               {'$ref': 'scheduler/jq-stage-schema.json#'}],
     'type': 'object'}

On instance['stages'][0]['scheduler']:
    {'parameters': [{'key': 'events',
                     'value': {'expression_type': 'stage-output-selector',
                               'output': 'events',
                               'step': 'init'}},
                    {'key': 'gendata',
                     'value': {'expression_type': 'stage-output-selector',
                               'output': 'gendata',
                               'step': 'init'}},
                    {'key': 'outfilename', 'value': '{workdir}/data.root'}],
     'scheduler_type': 'singlestep-stage',
     'step': {'process': {'interpreter': 'sh',
                          'process_type': 'interpolated-script-cmd',
                          'script': 'root -b -q '
                                    '\'{gendata}({events},"{outfilename}")\''},
              'publisher': {'outputmap': {'data': 'outfilename'},
                            'publisher_type': 'frompar-pub'},
              'xxxenvironment': {'environment_type': 'docker-encapsulated',
                                 'image': 'reanahub/reana-env-root6',
                                 'imagetag': '6.18.04'}}}
```