### PR TITLE
global: allow operational options in reana.yaml

### DIFF
--- a/reana_client/cli/files.py
+++ b/reana_client/cli/files.py
@@ -21,7 +21,7 @@ from reana_client.cli.utils import (add_access_token_options,
                                     filter_data, parse_parameters)
 from reana_client.config import ERROR_MESSAGES, JSON, URL
 from reana_client.errors import FileDeletionError, FileUploadError
-from reana_client.utils import (get_reana_yaml_file_path, load_reana_spec,
+from reana_client.utils import (get_reana_yaml_file_path,
                                 workflow_uuid_or_name)
 from reana_commons.utils import click_table_printer
 

--- a/reana_client/cli/utils.py
+++ b/reana_client/cli/utils.py
@@ -136,7 +136,7 @@ def validate_workflow_name(ctx, _, workflow_name):
     return workflow_name
 
 
-def params_tuple_to_dict(ctx, param, value):
+def key_value_to_dict(ctx, param, value):
     """Convert tuple params to dictionary. e.g `(foo=bar)` to `{'foo': 'bar'}`.
 
     :param options: A tuple with CLI operational options.

--- a/reana_client/cli/utils.py
+++ b/reana_client/cli/utils.py
@@ -136,6 +136,21 @@ def validate_workflow_name(ctx, _, workflow_name):
     return workflow_name
 
 
+def params_tuple_to_dict(ctx, param, value):
+    """Convert tuple params to dictionary. e.g `(foo=bar)` to `{'foo': 'bar'}`.
+
+    :param options: A tuple with CLI operational options.
+    :returns: A dictionary representation of the given options.
+    """
+    try:
+        return dict(op.split('=') for op in value)
+    except ValueError as err:
+        click.secho('==> ERROR: Input parameter "{0}" is not valid. '
+                    'It must follow format "param=value".'
+                    .format(' '.join(value)), err=True, fg='red'),
+        sys.exit(1)
+
+
 class NotRequiredIf(click.Option):
     """Allow only one of two arguments to be missing."""
 

--- a/reana_client/cli/workflow.py
+++ b/reana_client/cli/workflow.py
@@ -20,7 +20,7 @@ from reana_client.cli.files import get_files, upload_files
 from reana_client.cli.utils import (add_access_token_options,
                                     add_workflow_option, check_connection,
                                     filter_data, format_session_uri,
-                                    params_tuple_to_dict, parse_parameters,
+                                    key_value_to_dict, parse_parameters,
                                     validate_workflow_name)
 from reana_client.config import ERROR_MESSAGES, TIMECHECK
 from reana_client.utils import (get_reana_yaml_file_path,
@@ -281,7 +281,7 @@ def workflow_create(ctx, file, name,
 @click.option(
     '-p', '--parameter', 'parameters',
     multiple=True,
-    callback=params_tuple_to_dict,
+    callback=key_value_to_dict,
     help='Additional input parameters to override '
          'original ones from reana.yaml. '
          'E.g. -p myparam1=myval1 -p myparam2=myval2.',
@@ -289,7 +289,7 @@ def workflow_create(ctx, file, name,
 @click.option(
     '-o', '--option', 'options',
     multiple=True,
-    callback=params_tuple_to_dict,
+    callback=key_value_to_dict,
     help='Additional operational options for the workflow execution. '
          'E.g. CACHE=off. (workflow engine - serial) '
          'E.g. --debug (workflow engine - cwl)',
@@ -331,10 +331,9 @@ def workflow_start(ctx, workflow, access_token,
                 response = get_workflow_parameters(workflow, access_token)
                 workflow_type = response['type']
                 original_parameters = response['parameters']
-                parsed_parameters['operational_options'] = \
-                    validate_operational_options(
-                        workflow_type,
-                        parsed_parameters['operational_options'])
+                validate_operational_options(
+                    workflow_type,
+                    parsed_parameters['operational_options'])
 
                 parsed_parameters['input_parameters'] = \
                     validate_input_parameters(
@@ -395,7 +394,7 @@ def workflow_start(ctx, workflow, access_token,
 @click.option(
     '-p', '--parameter', 'parameters',
     multiple=True,
-    callback=params_tuple_to_dict,
+    callback=key_value_to_dict,
     help='Additional input parameters to override '
          'original ones from reana.yaml. '
          'E.g. -p myparam1=myval1 -p myparam2=myval2.',
@@ -403,7 +402,7 @@ def workflow_start(ctx, workflow, access_token,
 @click.option(
     '-o', '--option', 'options',
     multiple=True,
-    callback=params_tuple_to_dict,
+    callback=key_value_to_dict,
     help='Additional operational options for the workflow execution. '
          'E.g. CACHE=off. (workflow engine - serial) '
          'E.g. --debug (workflow engine - cwl)',
@@ -814,7 +813,7 @@ def workflow_stop(ctx, workflow, force_stop, access_token):  # noqa: D301
 @click.option(
     '-p', '--parameter', 'parameters',
     multiple=True,
-    callback=params_tuple_to_dict,
+    callback=key_value_to_dict,
     help='Additional input parameters to override '
          'original ones from reana.yaml. '
          'E.g. -p myparam1=myval1 -p myparam2=myval2.',
@@ -822,8 +821,8 @@ def workflow_stop(ctx, workflow, force_stop, access_token):  # noqa: D301
 @click.option(
     '-o', '--option', 'options',
     multiple=True,
-    callback=params_tuple_to_dict,
-    help='Additional operatioal options for the workflow execution. '
+    callback=key_value_to_dict,
+    help='Additional operational options for the workflow execution. '
          'E.g. CACHE=off.',
 )
 @click.option(

--- a/reana_client/cli/workflow.py
+++ b/reana_client/cli/workflow.py
@@ -255,7 +255,6 @@ def workflow_create(ctx, file, name,
     try:
         reana_specification = load_reana_spec(click.format_filename(file),
                                               skip_validation)
-        # TODO: Validate operational options
         logging.info('Connecting to {0}'.format(get_api_url()))
         response = create_workflow(reana_specification,
                                    name,

--- a/reana_client/schemas/reana_analysis_schema.json
+++ b/reana_client/schemas/reana_analysis_schema.json
@@ -109,6 +109,12 @@
             "title": "Analysis parameters.",
             "description": "Key value data structure which represents the analysis parameters.",
             "optional": true
+        },
+        "options": {
+          "id": "/properties/workflow/properties/options",
+          "type": "object",
+          "title": "Workflow operational options.",
+          "description": "Extra operational options accepted by workflow engines."
         }
       }
     },
@@ -133,12 +139,6 @@
           "type": "string",
           "title": "Workflow engine.",
           "description": "Name which represents a supported workflow engine to be used to reproduce the analysis."
-        },
-        "options": {
-          "id": "/properties/workflow/properties/options",
-          "type": "object",
-          "title": "Workflow additional options.",
-          "description": "Extra options accepted by workflow engines, e.g. `toplevel` for Yadage workflows."
         },
         "resources": {
           "id": "/properties/workflow/properties/resources",

--- a/reana_client/schemas/reana_analysis_schema.json
+++ b/reana_client/schemas/reana_analysis_schema.json
@@ -134,6 +134,12 @@
           "title": "Workflow engine.",
           "description": "Name which represents a supported workflow engine to be used to reproduce the analysis."
         },
+        "options": {
+          "id": "/properties/workflow/properties/options",
+          "type": "object",
+          "title": "Workflow additional options.",
+          "description": "Extra options accepted by workflow engines, e.g. `toplevel` for Yadage workflows."
+        },
         "resources": {
           "id": "/properties/workflow/properties/resources",
           "type": "object",

--- a/reana_client/utils.py
+++ b/reana_client/utils.py
@@ -83,10 +83,9 @@ def cwl_load(workflow_file, **kwargs):
     :returns: A dictionary which represents the valid `cwl` workflow.
     """
     result = \
-        subprocess.run(
-            ['cwltool', '--pack', '--quiet', workflow_file],
-            stdout=subprocess.PIPE)
-    value = result.stdout.decode('utf-8')
+        subprocess.check_output(
+            ['cwltool', '--pack', '--quiet', workflow_file])
+    value = result.decode('utf-8')
     return json.loads(value)
 
 

--- a/reana_client/utils.py
+++ b/reana_client/utils.py
@@ -38,7 +38,7 @@ def workflow_uuid_or_name(ctx, param, value):
         return value
 
 
-def yadage_load(workflow_file, toplevel='.'):
+def yadage_load(workflow_file, toplevel='.', **kwargs):
     """Validate and return yadage workflow specification.
 
     :param workflow_file: A specification file compliant with
@@ -124,20 +124,24 @@ def load_reana_spec(filepath, skip_validation=False):
             _validate_reana_yaml(reana_yaml)
 
         kwargs = {}
-        if reana_yaml['workflow']['type'] == 'serial':
+        workflow_type = reana_yaml['workflow']['type']
+        if workflow_type == 'serial':
             kwargs['specification'] = reana_yaml['workflow'].\
                 get('specification')
             kwargs['parameters'] = \
                 reana_yaml.get('inputs', {}).get('parameters', {})
             kwargs['original'] = True
 
+        if 'options' in reana_yaml['workflow']:
+            kwargs.update(reana_yaml['workflow']['options'])
+
         reana_yaml['workflow']['specification'] = load_workflow_spec(
-            reana_yaml['workflow']['type'],
+            workflow_type,
             reana_yaml['workflow'].get('file'),
             **kwargs
         )
 
-        if reana_yaml['workflow']['type'] == 'cwl' and \
+        if workflow_type == 'cwl' and \
                 'inputs' in reana_yaml:
             with open(reana_yaml['inputs']['parameters']['input']) as f:
                 reana_yaml['inputs']['parameters'] = \

--- a/reana_client/utils.py
+++ b/reana_client/utils.py
@@ -19,9 +19,9 @@ import click
 import yadageschemas
 import yaml
 from jsonschema import ValidationError, validate
-from reana_commons.serial import serial_load
 from reana_commons.errors import REANAValidationError
 from reana_commons.operational_options import validate_operational_options
+from reana_commons.serial import serial_load
 from reana_commons.utils import get_workflow_status_change_verb
 
 from reana_client.config import (reana_yaml_schema_file_path,
@@ -67,8 +67,8 @@ def yadage_load(workflow_file, toplevel='.', **kwargs):
     }
 
     try:
-        return yadageschemas.load(spec=workflow_file, specopts=specopts,
-                                  validopts=validopts, validate=True)
+        yadageschemas.load(spec=workflow_file, specopts=specopts,
+                           validopts=validopts, validate=True)
 
     except ValidationError as e:
         e.message = str(e)
@@ -115,7 +115,6 @@ def load_reana_spec(filepath, skip_validation=False):
     :raises ValidationError: Given REANA spec file does not validate against
         REANA specification.
     """
-
     def _prepare_kwargs(reana_yaml):
         kwargs = {}
         workflow_type = reana_yaml['workflow']['type']

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ install_requires = [
     'cwltool==1.0.20191022103248',
     'pyOpenSSL>=19.0.0',  # FIXME remove once yadage-schemas solves deps.
     'jsonpointer>=2.0',
-    'reana-commons>=0.7.0.dev20200319,<0.8.0',
+    'reana-commons>=0.7.0.dev20200408,<0.8.0',
     'rfc3987>=1.3.8',  # FIXME remove once yadage-schemas solves deps.
     'six==1.12.0',
     'strict-rfc3339>=0.7',  # FIXME remove once yadage-schemas solves deps.


### PR DESCRIPTION
closes #356

`reana.yaml` could be like:
```yaml
version: 0.6.0
[...]
workflow:
  type: yadage
  file: workflow.yaml
  options: 
    toplevel: './example'
[...]
```

###### TODO:
- [x] Validation of `reana.yaml` operational options on creation.
- [ ] Execute a CWL workflow with `-o TARGET ...` successfully.