### PR TITLE
cli: fix reana-common API ref.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,9 +52,9 @@ before_install:
   - travis_retry pip uninstall click -y
 
 install:
-  - pip install -r requirements-dev.txt
-  - travis_retry pip install -r .travis-${REQUIREMENTS}-requirements.txt
-  - travis_retry pip install -e .[$EXTRAS]
+  - pip install -I -r requirements-dev.txt
+  - travis_retry pip install -I -r .travis-${REQUIREMENTS}-requirements.txt
+  - travis_retry pip install -I -e .[$EXTRAS]
 
 script:
   - ./run-tests.sh

--- a/reana_client/api/client.py
+++ b/reana_client/api/client.py
@@ -35,7 +35,7 @@ current_rs_api_client = LocalProxy(
 def ping(access_token):
     """Health check REANA server."""
     try:
-        response, http_response = current_rs_api_client.api.get_me(
+        response, http_response = current_rs_api_client.api.get_you(
             access_token=access_token
         ).result()
         if http_response.status_code == 200:

--- a/reana_client/version.py
+++ b/reana_client/version.py
@@ -14,4 +14,4 @@ This file is imported by ``reana_client.__init__`` and parsed by
 
 from __future__ import absolute_import, print_function
 
-__version__ = "0.7.0.dev20200218"
+__version__ = "0.7.0.dev20200706"

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ install_requires = [
     "cwltool==1.0.20191022103248",
     "pyOpenSSL>=19.0.0",  # FIXME remove once yadage-schemas solves deps.
     "jsonpointer>=2.0",
-    "reana-commons>=0.7.0.dev20200408,<0.8.0",
+    "reana-commons>=0.7.0.dev20200625,<0.8.0",
     "rfc3987>=1.3.8",  # FIXME remove once yadage-schemas solves deps.
     "six==1.12.0",
     "strict-rfc3339>=0.7",  # FIXME remove once yadage-schemas solves deps.


### PR DESCRIPTION
This PR addresses an outdated `reana-commons` API reference (issue https://github.com/reanahub/reana-client/issues/417).

In addition I have:
- Bumped up the package version.
- Bumped up the `reana-commons` min. version to ensure it references its updated API.