### PR TITLE
cli: filter logs

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -3,6 +3,7 @@ Authors
 
 The list of contributors in alphabetical order:
 
+- `Adelina Lintuluoto <https://orcid.org/0000-0002-0726-1452>`_
 - `Anton Khodak <https://orcid.org/0000-0003-3263-4553>`_
 - `Daniel Prelipcean <https://orcid.org/0000-0002-4855-194X>`_
 - `Diego Rodriguez <https://orcid.org/0000-0003-0649-2002>`_

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changes
 Version master (UNRELEASED)
 ---------------------------
 
+- Adds option to filter job logs according to compute backend, docker image, status and steps.
 - Enriches disk usage output format.
 - Adds new command to restart workflows.
 - Optimizes CLI performance.


### PR DESCRIPTION
closes #415

Generic way to filter the logs according to `step`, `compute_backend`, `docker_img` and `status`. Replaces the current `-s` `--step` option that returns the logs of desired steps.

Use example

```
$ reana-client logs --filter status=failed --filter compute_backend=htcondor
$ reana-client logs --filter step=gendata
```