### PR TITLE
docs: revert cli api docs autogeneration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,7 @@ target/
 
 # Visual Studio Code files
 .vscode/*
+
+# Docs autogeneration
+cmd_list.txt
+cli_api.md

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -21,3 +21,4 @@ recursive-include docs *.py
 recursive-include docs *.png
 recursive-include docs *.rst
 recursive-include tests *.py
+recursive-include scripts *.py

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -12,17 +12,22 @@ set -o errexit
 # Quit on unbound symbols
 set -o nounset
 
+
+cli_docs_url=https://raw.githubusercontent.com/reanahub/docs.reana.io/master/docs/reference/reana-client-cli-api/index.md
+docs_differ_error_msg='Current reana-client differs with the documentation. Please update http://docs.reana.io/reference/reana-client-cli-api/.'
 python_version=$(python -c 'import sys;  print(sys.version_info.major)')
 
-
 pydocstyle reana_client
-if [ "$python_version" -eq 3 ]
-then
-    black --check .
-fi
 reana-client --help > cmd_list.txt
 diff -q -w docs/cmd_list.txt cmd_list.txt
 rm cmd_list.txt
+if [ "$python_version" -eq 3 ]
+then
+    black --check .
+    python scripts/generate_cli_api.py > cli_api.md
+    (diff -q -w  cli_api.md <(curl -s $cli_docs_url) || (echo $docs_differ_error_msg && exit 1))
+    rm cli_api.md
+fi
 check-manifest --ignore ".travis-*"
 sphinx-build -qnNW docs docs/_build/html
 python setup.py test

--- a/scripts/generate_cli_api.py
+++ b/scripts/generate_cli_api.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of REANA.
+# Copyright (C) 2020 CERN.
+#
+# REANA is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+"""REANA client CLI API docs generation."""
+
+import click
+
+from reana_client.cli import cli
+
+CLI_API_URL = "https://reana-client.readthedocs.io/en/latest/#cli-api"
+
+
+def _print_code_block(content, lang=""):
+    print("```{}".format(lang))
+    print(content)
+    print("```")
+
+
+def generate_cli_docs():
+    """Generate Markdown friendly CLI API documentation."""
+    print("# reana-client CLI API\n")
+    print("The complete `reana-client` CLI API reference guide is available here:\n")
+    print(f"- [{CLI_API_URL}]({CLI_API_URL})\n")
+    with click.Context(cli) as ctx:
+        _print_code_block(cli.get_help(ctx), lang="console")
+
+    for cmd_group in cli.cmd_groups:
+        print("\n## {}".format(cmd_group.help))
+        for cmd_obj in cmd_group.commands.values():
+            print("\n### {}\n".format(cmd_obj.name))
+            print(cmd_obj.help)
+
+
+if __name__ == "__main__":
+    generate_cli_docs()


### PR DESCRIPTION
- adds link pointing to full docs (readthedocs)

addresses reanahub/reana#335