### PR TITLE
cli: check htcondor_max_runtime

### DIFF
--- a/reana_client/cli/workflow.py
+++ b/reana_client/cli/workflow.py
@@ -34,6 +34,7 @@ from reana_client.cli.utils import (
     parse_filter_parameters,
     parse_format_parameters,
     validate_workflow_name,
+    check_htcondor_max_runtime,
 )
 from reana_client.config import ERROR_MESSAGES, RUN_STATUSES, TIMECHECK
 from reana_client.utils import (
@@ -298,6 +299,9 @@ def workflow_create(ctx, file, name, skip_validation, access_token):  # noqa: D3
         reana_specification = load_reana_spec(
             click.format_filename(file), skip_validation
         )
+        click.echo(reana_specification)
+        if not check_htcondor_max_runtime(reana_specification):
+            return Exception("Invalid input in htcondor_max_runtime.")
         logging.info("Connecting to {0}".format(get_api_url()))
         response = create_workflow(reana_specification, name, access_token)
         click.echo(click.style(response["workflow_name"], fg="green"))


### PR DESCRIPTION
People submitting e.g. `htcondor_max_runtime = epreso` (or any other typo) will see that their workflow runs but it will eventually specify no `JobFlavour` (it will use the default `MaxRunTime`) which is not what they meant.

If we move this check before in time and we make it more strict (e.g. if string check if it is in the list otherwise fail), we can be more correct and avoid unnecessary use of resources:
- If we do it in REANA-Client:
  - We avoid doing a call to the REANA cluster before the check passes
  - We give faster feedback to users (instead of waiting for minutes to realise that what they wanted didn't happen)

_Originally posted by @diegodelemos in https://github.com/reanahub/reana-job-controller/pull/278#discussion_r517156957_

closes reanahub/reana-job-controller#32