### PR TITLE
cli: fix exception handling on file upload

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Version 0.7.1 (2020-11-10)
 --------------------------
 
 - Changes ``ping`` command output to include REANA client and server version information.
+- Fixes ``upload`` command to properly display errors.
 
 Version 0.7.0 (2020-10-20)
 --------------------------

--- a/reana_client/api/client.py
+++ b/reana_client/api/client.py
@@ -289,7 +289,9 @@ def upload_file(workflow_id, file_, file_name, access_token):
             headers={"Content-Type": "application/octet-stream"},
             verify=False,
         )
-        return http_response.json()
+        if http_response.ok:
+            return http_response.json()
+        raise Exception(http_response.json().get("message"))
     except requests.exceptions.ConnectionError:
         logging.debug("File could not be uploaded.", exc_info=True)
         raise Exception("Could not connect to the server {}".format(get_api_url()))
@@ -303,9 +305,7 @@ def upload_file(workflow_id, file_, file_name, access_token):
         logging.debug(
             "Something went wrong while connecting to the server.", exc_info=True
         )
-        raise Exception(
-            "The request to the server has failed for an " "unknown reason."
-        )
+        raise Exception("The request to the server has failed for an unknown reason.")
     except Exception as e:
         raise e
 
@@ -525,9 +525,7 @@ def upload_to_server(workflow, paths, access_token):
                 logging.info("Uploading '{}' ...".format(fname))
                 try:
                     upload_file(workflow, f, save_path, access_token)
-                    logging.info(
-                        "File '{}' was successfully " "uploaded.".format(fname)
-                    )
+                    logging.info("File '{}' was successfully uploaded.".format(fname))
                     if symlink:
                         save_path = "symlink:{}".format(save_path)
                     return [save_path]
@@ -537,6 +535,7 @@ def upload_to_server(workflow, paths, access_token):
                     logging.info(
                         "Something went wrong while uploading {}".format(fname)
                     )
+                    raise e
 
 
 def get_workflow_parameters(workflow, access_token):

--- a/reana_client/cli/files.py
+++ b/reana_client/cli/files.py
@@ -326,7 +326,9 @@ def upload_files(ctx, workflow, filenames, access_token):  # noqa: D301
                     logging.debug(str(e))
                     click.echo(
                         click.style(
-                            "Something went wrong while uploading {}".format(filename),
+                            "Something went wrong while uploading {}: \n{}".format(
+                                filename, str(e)
+                            ),
                             fg="red",
                         ),
                         err=True,


### PR DESCRIPTION
For compatibility reasons between cluster 0.8.x and client 0.7.x
When quota is already exceeded:

**Before:**
```console
$ reana-client upload -w helloworld LICENSE                                                                                                                                                                              
File /LICENSE was successfully uploaded.       
```
_(even though the file is not uploaded)_

**After:**
```console
$ reana-client upload -w helloworld 800Kfile.dat
Something went wrong while uploading /Users/marco/code/reanahub/reana-demo-helloworld/800Kfile.dat: 
User quota exceeded.
```