### PR TITLE
cli: remove traling slash from reana server url

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,12 +1,13 @@
 Changes
 =======
 
-Version 0.7.2 (UNRELEASED)
+Version 0.7.2 (2021-01-15)
 --------------------------
 
 - Adds support for Python 3.9.
 - Fixes exception handling when uploading files.
 - Fixes minor code warnings.
+- Fixes traling slash issue from user exported REANA_SERVER_URL.
 
 Version 0.7.1 (2020-11-10)
 --------------------------

--- a/reana_client/cli/__init__.py
+++ b/reana_client/cli/__init__.py
@@ -14,6 +14,7 @@ import click
 from urllib3 import disable_warnings
 
 from reana_client.cli import workflow, files, ping, secrets
+from reana_client.utils import get_api_url
 
 DEBUG_LOG_FORMAT = (
     "[%(asctime)s] p%(process)s "
@@ -29,7 +30,7 @@ class Config(object):
 
     def __init__(self):
         """Initialize config variables."""
-        self.reana_server_url = os.getenv("REANA_SERVER_URL", None)
+        self.reana_server_url = get_api_url()
 
 
 class ReanaCLI(click.Group):

--- a/reana_client/utils.py
+++ b/reana_client/utils.py
@@ -357,7 +357,8 @@ def parse_secret_from_path(path):
 
 def get_api_url():
     """Obtain REANA server API URL."""
-    return os.environ.get("REANA_SERVER_URL")
+    server_url = os.getenv("REANA_SERVER_URL", None)
+    return server_url.strip(" \t\n\r/") if server_url else None
 
 
 def get_reana_yaml_file_path():

--- a/reana_client/version.py
+++ b/reana_client/version.py
@@ -14,4 +14,4 @@ This file is imported by ``reana_client.__init__`` and parsed by
 
 from __future__ import absolute_import, print_function
 
-__version__ = "0.7.1"
+__version__ = "0.7.2"


### PR DESCRIPTION
Removes trailing whitespaces, backslahes, new line characters and tabs from user exported `REANA_SERVER_URL`.

Steps to test:
```python

$ reana-client create -w test -f reana-demo-helloworld/reana.yaml
$ export REANA_SERVER_URL=https://localhost:30443// \n
$ reana-client open -w test

https://localhost:30443/token # result
```

closes #453