### PR TITLE
validate: uid/gid environment validation for serial

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,10 @@
 Changes
 =======
 
+Version 0.7.3 (UNRELEASED)
+--------------------------
+- Adds option ``--environments` to ``validate`` to perform workflow image validations.
+
 Version 0.7.2 (2021-01-15)
 --------------------------
 

--- a/reana_client/config.py
+++ b/reana_client/config.py
@@ -42,3 +42,7 @@ WORKFLOW_ENGINES = ["serial", "cwl", "yadage"]
 
 ENVIRONMENT_IMAGE_SUSPECTED_TAGS_VALIDATOR = ["latest", "master", ""]
 """Warns user if above environment image tags are used."""
+
+
+DOCKER_REGISTRY_INDEX_URL = "https://index.docker.io/v1/repositories/{image}/tags/{tag}"
+"""Docker Hub registry index URL."""

--- a/reana_client/utils.py
+++ b/reana_client/utils.py
@@ -207,31 +207,46 @@ def _validate_serial_workflow_environment(workflow_steps):
     :raises Warning: Warns user if the workflow environment is invalid in serial workflow steps.
     """
     for step in workflow_steps:
-        if ":" in step["environment"]:
-            environment = step["environment"].split(":", 1)
-            environment_image, environment_image_tag = environment[0], environment[-1]
-            if ":" in environment_image_tag:
-                logging.warning(
-                    "Image {} has invalid tag {}".format(
-                        environment_image, environment_image_tag
-                    )
-                )
-                sys.exit(1)
-            elif environment_image_tag in ENVIRONMENT_IMAGE_SUSPECTED_TAGS_VALIDATOR:
-                logging.warning(
-                    "Using '{}' tag is not recommended in {} image.".format(
-                        environment_image_tag, environment_image
-                    )
-                )
-                sys.exit(1)
-        else:
-            logging.warning(
-                "Image {} does not have an explicit tag.".format(step["environment"])
+        _validate_image_tag(step["environment"])
+
+
+def _validate_image_tag(image):
+    """Validate if image tag is valid."""
+
+    has_warnings = False
+    if ":" in image:
+        environment = image.split(":", 1)
+        image_name, image_tag = environment[0], environment[-1]
+        if ":" in image_tag:
+            click.secho(
+                "==> ERROR: Environment image {} has invalid tag '{}'".format(
+                    image_name, image_tag
+                ),
+                err=True,
+                fg="red",
             )
             sys.exit(1)
+        elif image_tag in ENVIRONMENT_IMAGE_SUSPECTED_TAGS_VALIDATOR:
+            click.secho(
+                "==> WARNING: Using '{}' tag is not recommended in {} environment image.".format(
+                    image_tag, image_name
+                ),
+                fg="yellow",
+            )
+            has_warnings = True
+    else:
+        click.secho(
+            "==> WARNING: Environment image {} does not have an explicit tag.".format(
+                image
+            ),
+            fg="yellow",
+        )
+        has_warnings = True
+    if not has_warnings:
         click.echo(
             click.style(
-                "Image {} has correct format.".format(step["environment"]), fg="green",
+                "==> Environment image {} has correct format.".format(image),
+                fg="green",
             )
         )
 

--- a/reana_client/utils.py
+++ b/reana_client/utils.py
@@ -7,6 +7,7 @@
 # under the terms of the MIT License; see LICENSE file for more details.
 """REANA client utils."""
 import base64
+import datetime
 import json
 import logging
 import os
@@ -16,16 +17,22 @@ import traceback
 from uuid import UUID
 
 import click
+import requests
 import yadageschemas
 import yaml
 from jsonschema import ValidationError, validate
-from reana_client.config import ENVIRONMENT_IMAGE_SUSPECTED_TAGS_VALIDATOR
+from reana_commons.config import WORKFLOW_RUNTIME_USER_GID, WORKFLOW_RUNTIME_USER_UID
 from reana_commons.errors import REANAValidationError
 from reana_commons.operational_options import validate_operational_options
 from reana_commons.serial import serial_load
 from reana_commons.utils import get_workflow_status_change_verb
 
-from reana_client.config import reana_yaml_schema_file_path, reana_yaml_valid_file_names
+from reana_client.config import (
+    reana_yaml_schema_file_path,
+    reana_yaml_valid_file_names,
+    DOCKER_REGISTRY_INDEX_URL,
+    ENVIRONMENT_IMAGE_SUSPECTED_TAGS_VALIDATOR,
+)
 
 
 def workflow_uuid_or_name(ctx, param, value):
@@ -207,12 +214,16 @@ def _validate_serial_workflow_environment(workflow_steps):
     :raises Warning: Warns user if the workflow environment is invalid in serial workflow steps.
     """
     for step in workflow_steps:
-        _validate_image_tag(step["environment"])
+        image = step["environment"]
+        image_name, image_tag = _validate_image_tag(image)
+        _image_exists(image_name, image_tag)
+        uid, gids = _get_image_uid_gids(image_name, image_tag)
+        _validate_uid_gids(uid, gids, kubernetes_uid=step.get("kubernetes_uid"))
 
 
 def _validate_image_tag(image):
     """Validate if image tag is valid."""
-
+    image_name, image_tag = "", ""
     has_warnings = False
     if ":" in image:
         environment = image.split(":", 1)
@@ -242,12 +253,117 @@ def _validate_image_tag(image):
             fg="yellow",
         )
         has_warnings = True
+        image_name = image
     if not has_warnings:
         click.echo(
             click.style(
                 "==> Environment image {} has correct format.".format(image),
                 fg="green",
             )
+        )
+    return image_name, image_tag
+
+
+def _image_exists(image, tag):
+    """Verify if image exists."""
+
+    docker_registry_url = DOCKER_REGISTRY_INDEX_URL.format(image=image, tag=tag)
+    # Remove traling slash if no tag was specified
+    if not tag:
+        docker_registry_url = docker_registry_url[:-1]
+    try:
+        response = requests.get(docker_registry_url)
+    except requests.exceptions.RequestException as e:
+        logging.error(traceback.format_exc())
+        click.secho(
+            "==> ERROR: Something went wrong when querying {}".format(
+                docker_registry_url
+            ),
+            err=True,
+            fg="red",
+        )
+        raise e
+
+    if not response.ok:
+        if response.status_code == 404:
+            msg = response.text
+            click.secho(
+                "==> ERROR: Environment image {}{} does not exist: {}".format(
+                    image, ":{}".format(tag) if tag else "", msg
+                ),
+                err=True,
+                fg="red",
+            )
+        else:
+            click.secho(
+                "==> ERROR: Existence of environment image {}{} could not be verified. Status code: {} {}".format(
+                    image,
+                    ":{}".format(tag) if tag else "",
+                    response.status_code,
+                    response.reason,
+                ),
+                err=True,
+                fg="red",
+            )
+        sys.exit(1)
+    else:
+        click.secho(
+            "==> Environment image {}{} exists.".format(
+                image, ":{}".format(tag) if tag else ""
+            ),
+            fg="green",
+        )
+
+
+def _get_image_uid_gids(image, tag):
+    """Obtain environment image UID and GIDs.
+
+    :returns: A tuple with UID and GIDs.
+    """
+    # Check if docker is installed.
+    run_command("docker version", display=False, return_output=True)
+    # Run ``id``` command inside the container.
+    uid_gid_output = run_command(
+        'docker run -i -t --rm {}{} bash -c "/usr/bin/id -u && /usr/bin/id -G"'.format(
+            image, ":{}".format(tag) if tag else ""
+        ),
+        display=False,
+        return_output=True,
+    )
+    ids = uid_gid_output.splitlines()
+    uid, gids = (
+        int(ids[0]),
+        [int(gid) for gid in ids[1].split()],
+    )
+    return uid, gids
+
+
+def _validate_uid_gids(uid, gids, kubernetes_uid=None):
+    """Check whether container UID and GIDs are valid."""
+    if WORKFLOW_RUNTIME_USER_GID not in gids:
+        click.secho(
+            "==> ERROR: Environment image GID must be {}. GIDs {} were found.".format(
+                WORKFLOW_RUNTIME_USER_GID, gids
+            ),
+            err=True,
+            fg="red",
+        )
+        sys.exit(1)
+    if kubernetes_uid is not None:
+        if kubernetes_uid != uid:
+            click.secho(
+                "==> WARNING: `kubernetes_uid` set to {}. UID {} was found.".format(
+                    kubernetes_uid, uid
+                ),
+                fg="yellow",
+            )
+    elif uid != WORKFLOW_RUNTIME_USER_UID:
+        click.secho(
+            "==> WARNING: Environment image UID is recommended to be {}. UID {} was found.".format(
+                WORKFLOW_RUNTIME_USER_UID, uid
+            ),
+            err=True,
+            fg="yellow",
         )
 
 
@@ -467,3 +583,32 @@ def get_reana_yaml_file_path():
             return path
     # If none of the valid paths exists, fall back to reana.yaml.
     return "reana.yaml"
+
+
+def run_command(cmd, display=True, return_output=False):
+    """Run given command on shell in the current directory.
+
+    Exit in case of troubles.
+
+    :param cmd: shell command to run
+    :param display: should we display command to run?
+    :param return_output: shall the output of the command be returned?
+    :type cmd: str
+    :type display: bool
+    :type return_output: bool
+    """
+    now = datetime.datetime.now().strftime("%Y-%m-%dT%H:%M:%S")
+    if display:
+        click.secho("[{0}] ".format(now), bold=True, nl=False, fg="green")
+        click.secho("{0}".format(cmd), bold=True)
+    try:
+        if return_output:
+            result = subprocess.check_output(cmd, shell=True)
+            return result.decode().rstrip("\r\n")
+        else:
+            subprocess.check_call(cmd, shell=True)
+    except subprocess.CalledProcessError as err:
+        if display:
+            click.secho("[{0}] ".format(now), bold=True, nl=False, fg="green")
+            click.secho("{0}".format(err), bold=True, fg="red")
+        sys.exit(err.returncode)

--- a/tests/test_validate_environments.py
+++ b/tests/test_validate_environments.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of REANA.
+# Copyright (C) 2021 CERN.
+#
+# REANA is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""REANA client validate environments tests."""
+
+import pytest
+
+from reana_client.utils import _validate_image_tag
+
+
+@pytest.mark.parametrize(
+    "image, output, exit_",
+    [
+        ("foo:bar", "has correct format", False),
+        ("foo/bar:baz", "has correct format", False),
+        ("foo/bar", "not have an explicit tag", False),
+        ("foo/bar:", "tag is not recommended", False),
+        ("foo/bar:latest", "tag is not recommended", False),
+        ("foo:master", "tag is not recommended", False),
+        ("foo:bar:baz", "has invalid tag", True),
+        ("foo:bar:", "has invalid tag", True),
+    ],
+)
+def test_validate_environment_image_tag(image, output, exit_, capsys):
+    """Validate workflow environment image tags."""
+    if exit_:
+        with pytest.raises(SystemExit):
+            _validate_image_tag(image)
+    else:
+        _validate_image_tag(image)
+    captured = capsys.readouterr()
+    assert output in (captured.err if exit_ else captured.out)


### PR DESCRIPTION
closes #457 
closes #382

#### To test:
- To run: `reana-client validate --environments`
- Choose a `reana-demo-*` and play removing environment tags, adding invalid ones, etc.
- Add `kubernetes_uid` to remove warnings for e.g. ATLAS images.