### PR TITLE
docs: added get_workflow_logs function under rest API docs section

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -21,7 +21,7 @@ API docs
 ========
 
 .. automodule:: reana_client.api.client
-  :members: create_workflow_from_json, upload_to_server, upload_file, start_workflow, list_files, get_workflow_status, download_file
+  :members: create_workflow_from_json, upload_to_server, upload_file, start_workflow, list_files, get_workflow_status, download_file, get_workflow_logs
 
 .. include:: ../CHANGES.rst
 

--- a/reana_client/api/client.py
+++ b/reana_client/api/client.py
@@ -313,7 +313,14 @@ def upload_file(workflow, file_, file_name, access_token):
 
 
 def get_workflow_logs(workflow, access_token, steps=None, page=None, size=None):
-    """Get logs from a workflow engine."""
+    """Get logs from a workflow engine.
+
+    :param workflow: name or id which identifies the workflow.
+    :param access_token: access token of the current user.
+    :param steps: list of step names to get logs for.
+    :param page: page number of returned log list.
+    :param size: page size of returned log list.
+    """
     try:
         (response, http_response) = current_rs_api_client.api.get_workflow_logs(
             workflow_id_or_name=workflow,


### PR DESCRIPTION
It would be good to expose also `get_workflow_logs` function in the docs, since it will be used in the blog post 