### PR TITLE
validate: enrich output messages

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,8 +3,8 @@ Changes
 
 Version 0.7.3 (UNRELEASED)
 --------------------------
-- Adds option ``--environments` to ``validate`` to perform workflow image validations.
 - Adds workflow parameters validation to ``validate`` command.
+- Adds option ``--environments`` to ``validate`` to perform workflow image validations.
 
 Version 0.7.2 (2021-01-15)
 --------------------------

--- a/reana_client/cli/workflow.py
+++ b/reana_client/cli/workflow.py
@@ -30,6 +30,7 @@ from reana_client.cli.utils import (
     validate_workflow_name,
 )
 from reana_client.config import ERROR_MESSAGES, TIMECHECK
+from reana_client.printer import display_message
 from reana_client.utils import (
     get_reana_yaml_file_path,
     get_workflow_name_and_run_number,
@@ -287,9 +288,7 @@ def workflow_create(ctx, file, name, skip_validation, access_token):  # noqa: D3
     # Otherwise it would mess up `--workflow` flag usage because no distinction
     # could be made between the name and actual UUID of workflow.
     if is_uuid_v4(name):
-        click.echo(
-            click.style("Workflow name cannot be a valid UUIDv4", fg="red"), err=True
-        )
+        display_message("Workflow name cannot be a valid UUIDv4", msg_type="error")
     try:
         reana_specification = load_reana_spec(
             click.format_filename(file), skip_validation
@@ -303,11 +302,8 @@ def workflow_create(ctx, file, name, skip_validation, access_token):  # noqa: D3
     except Exception as e:
         logging.debug(traceback.format_exc())
         logging.debug(str(e))
-        click.echo(
-            click.style(
-                "Cannot create workflow {}: \n{}".format(name, str(e)), fg="red"
-            ),
-            err=True,
+        display_message(
+            "Cannot create workflow {}: \n{}".format(name, str(e)), msg_type="error"
         )
         if "invoked_by_subcommand" in ctx.parent.__dict__:
             sys.exit(1)
@@ -896,35 +892,28 @@ def workflow_validate(ctx, file, environments, pull):  # noqa: D301
             skip_validate_environments=not environments,
             pull_environment_image=pull,
         )
-        click.echo(
-            click.style(
-                "File {filename} is a valid REANA specification file.".format(
-                    filename=click.format_filename(file)
-                ),
-                fg="green",
-            )
+        display_message(
+            "File {filename} is a valid REANA specification file.".format(
+                filename=click.format_filename(file)
+            ),
+            msg_type="success",
         )
 
     except ValidationError as e:
         logging.debug(traceback.format_exc())
         logging.debug(str(e))
-        click.echo(
-            click.style(
-                "{0} is not a valid REANA specification:\n{1}".format(
-                    click.format_filename(file), e.message
-                ),
-                fg="red",
+        display_message(
+            "{0} is not a valid REANA specification:\n{1}".format(
+                click.format_filename(file), e.message
             ),
-            err=True,
+            msg_type="error",
         )
     except Exception as e:
         logging.debug(traceback.format_exc())
         logging.debug(str(e))
-        click.echo(
-            click.style(
-                "Something went wrong when trying to validate {}".format(file), fg="red"
-            ),
-            err=True,
+        display_message(
+            "Something went wrong when trying to validate {}".format(file),
+            msg_type="error",
         )
 
 

--- a/reana_client/config.py
+++ b/reana_client/config.py
@@ -56,3 +56,12 @@ GITLAB_CERN_REGISTRY_PREFIX = "gitlab-registry.cern.ch"
 
 COMMAND_DANGEROUS_OPERATIONS = ["sudo ", "cd /"]
 """Operations in workflow commands considered dangerous."""
+
+PRINTER_COLOUR_SUCCESS = "green"
+"""Default colour for success messages on terminal."""
+
+PRINTER_COLOUR_WARNING = "yellow"
+"""Default colour for warning messages on terminal."""
+
+PRINTER_COLOUR_ERROR = "red"
+"""Default colour for error messages on terminal."""

--- a/reana_client/printer.py
+++ b/reana_client/printer.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of REANA.
+# Copyright (C) 2021 CERN.
+#
+# REANA is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""reana-client output print configuration."""
+
+import click
+
+from reana_client.config import (
+    PRINTER_COLOUR_ERROR,
+    PRINTER_COLOUR_SUCCESS,
+    PRINTER_COLOUR_WARNING,
+)
+
+
+def display_message(msg, msg_type=None, indented=False):
+    """Display messages in console.
+
+    :param msg: Message to display
+    :param msg_type: Type of message (info/note/warning/error)
+    :param indented: Message indented or not
+    :type msg: str
+    :type msg_type: str
+    :type indented: bool
+    """
+    msg_color_map = {
+        "success": PRINTER_COLOUR_SUCCESS,
+        "warning": PRINTER_COLOUR_WARNING,
+        "error": PRINTER_COLOUR_ERROR,
+    }
+    msg_color = msg_color_map.get(msg_type, "")
+
+    if msg_type == "info":
+        click.secho("==> ", bold=True, nl=False)
+        click.secho("{}".format(msg), bold=True, nl=True)
+    elif msg_type in ["error", "warning", "success"]:
+        prefix_tpl = "  -> {}: " if indented else "==> {}: "
+        click.secho(
+            prefix_tpl.format(msg_type.upper()),
+            bold=True,
+            nl=False,
+            err=msg_type == "error",
+            fg="{}".format(msg_color),
+        )
+        click.secho("{}".format(msg), bold=False, err=msg_type == "error", nl=True)
+    else:
+        click.secho("{}".format(msg), nl=True)

--- a/reana_client/utils.py
+++ b/reana_client/utils.py
@@ -30,6 +30,7 @@ from reana_client.config import (
     reana_yaml_schema_file_path,
     reana_yaml_valid_file_names,
 )
+from reana_client.printer import display_message
 from reana_client.validation import validate_environment, validate_parameters
 
 
@@ -158,22 +159,21 @@ def load_reana_spec(
         )
 
         if not skip_validation:
-            logging.info(
-                "Validating REANA specification file: {filepath}".format(
+            display_message(
+                "Verifing REANA specification file... {filepath}".format(
                     filepath=filepath
-                )
+                ),
+                msg_type="info",
             )
             _validate_reana_yaml(reana_yaml)
-            logging.info(
-                "Validating parameters in REANA specification file: "
-                "{filepath}".format(filepath=filepath)
+            display_message(
+                "Verifing workflow parameters and commands... ", msg_type="info",
             )
             validate_parameters(workflow_type, reana_yaml)
 
         if not skip_validate_environments:
-            logging.info(
-                "Validating environments in REANA specification file: "
-                "{filepath}".format(filepath=filepath)
+            display_message(
+                "Verifing environments in REANA specification file...", msg_type="info",
             )
             validate_environment(reana_yaml, pull=pull_environment_image)
 
@@ -214,6 +214,7 @@ def _validate_reana_yaml(reana_yaml):
             reana_yaml_schema = json.loads(f.read())
 
             validate(reana_yaml, reana_yaml_schema)
+        display_message("reana.yaml is valid.", msg_type="success", indented=True)
 
     except IOError as e:
         logging.info(


### PR DESCRIPTION
Paves the way to implement https://github.com/reanahub/reana-client/issues/431

### How it looks
![image](https://user-images.githubusercontent.com/8863238/111494636-ec78e480-873e-11eb-8593-b3f8f18f6be8.png)

![image](https://user-images.githubusercontent.com/8863238/111494550-dbc86e80-873e-11eb-825b-339474169c17.png)

### To test
Run `reana-client validate` or `reana-client validate --environments --pull` with any of our examples for any workflow engine.
- To force warnings: e.g. add dangerous operations (`sudo` , `cd /`) to workflow commands, add unused parameters, use undefined parameters..
- To force errors: e.g. modify env images to non-existing ones.