### PR TITLE
cli: support glob patterns when listing files

### DIFF
--- a/reana_client/api/client.py
+++ b/reana_client/api/client.py
@@ -433,11 +433,12 @@ def delete_file(workflow, file_name, access_token):
         raise e
 
 
-def list_files(workflow, access_token, page=None, size=None):
+def list_files(workflow, access_token, file_name=None, page=None, size=None):
     """Return the list of files for a given workflow workspace.
 
     :param workflow: name or id which identifies the workflow.
     :param access_token: access token of the current user.
+    :param file_name: file name(s) (glob) to list.
     :param page: page number of returned file list.
     :param size: page size of returned file list.
     :returns: a list of dictionaries composed by the `name`, `size` and
@@ -447,6 +448,7 @@ def list_files(workflow, access_token, page=None, size=None):
         (response, http_response) = current_rs_api_client.api.get_files(
             workflow_id_or_name=workflow,
             access_token=access_token,
+            file_name=file_name,
             page=page,
             size=size,
         ).result()

--- a/reana_client/cli/files.py
+++ b/reana_client/cli/files.py
@@ -66,11 +66,12 @@ def files_group(ctx):
     default=None,
     help="Get URLs of output files.",
 )
+@click.argument("filename", metavar="SOURCE", nargs=1, required=False)
 @add_access_token_options
 @add_pagination_options
 @click.pass_context
 def get_files(
-    ctx, workflow, _filter, output_format, access_token, page, size
+    ctx, workflow, _filter, output_format, filename, access_token, page, size
 ):  # noqa: D301
     """List workspace files.
 
@@ -79,8 +80,9 @@ def get_files(
     `--workflow` or `-w`.
 
     Examples: \n
-    \t $ reana-client ls --workflow myanalysis.42
-    """
+    \t $ reana-client ls --workflow myanalysis.42 \n
+    \t $ reana-client ls --workflow myanalysis.42 'code/\*'
+    """  # noqa: W605
     import tablib
     from reana_client.api.client import current_rs_api_client, list_files
 
@@ -93,7 +95,7 @@ def get_files(
     if workflow:
         logging.info('Workflow "{}" selected'.format(workflow))
         try:
-            response = list_files(workflow, access_token, page, size)
+            response = list_files(workflow, access_token, filename, page, size)
             headers = ["name", "size", "last-modified"]
             data = []
             file_path = get_path_from_operation_id(


### PR DESCRIPTION
closes #225

#### To test:

```console
$ export REANA_WORKON=helloworld
$ reana-client run
$ reana-client ls
$ reana-client ls '**/*.py'
$ reana-client ls 'code/*'
$ touch code/test.txt && reana-client upload code/test.txt
$ reana-client ls '**/*.txt'
```