### PR TITLE
cli: list deleted workflows by default

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changes
 Version 0.7.4 (UNRELEASED)
 --------------------------
 - Fixes environment image validation info message where UIDs were switched.
+- Changes ``list`` command to include deleted workflows by default.
 
 Version 0.7.3 (2021-03-24)
 --------------------------

--- a/reana_client/cli/workflow.py
+++ b/reana_client/cli/workflow.py
@@ -81,7 +81,11 @@ def workflow_execution_group(ctx):
     help="Get output in JSON format.",
 )
 @click.option(
-    "--all", "show_all", count=True, help="Show all workflows including deleted ones."
+    "--all",
+    "show_all",
+    count=True,
+    default=True,
+    help="Show all workflows including deleted ones.",
 )
 @click.option(
     "-v",


### PR DESCRIPTION
Add --exclude-deleted option to hide deleted workflows

Addresses #482 

<img width="750" alt="Screenshot 2021-03-24 at 10 58 34 AM" src="https://user-images.githubusercontent.com/24358501/112290850-e7acb700-8c8f-11eb-9867-b9e9a8480d9e.png">

