### PR TITLE
cli: support dir and glob pattern on download 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ Version 0.7.4 (UNRELEASED)
 --------------------------
 - Fixes environment image validation info message where UIDs were switched.
 - Changes ``list`` command to include deleted workflows by default.
+- Adds support of wildcard patterns to ``ls`` command.
+- Adds support of directory download and wildcard patterns to ``download`` command.
 
 Version 0.7.3 (2021-03-24)
 --------------------------

--- a/reana_client/api/client.py
+++ b/reana_client/api/client.py
@@ -439,11 +439,12 @@ def delete_file(workflow, file_name, access_token):
         raise e
 
 
-def list_files(workflow, access_token, page=None, size=None):
+def list_files(workflow, access_token, file_name=None, page=None, size=None):
     """Return the list of files for a given workflow workspace.
 
     :param workflow: name or id which identifies the workflow.
     :param access_token: access token of the current user.
+    :param file_name: file name(s) (glob) to list.
     :param page: page number of returned file list.
     :param size: page size of returned file list.
     :returns: a list of dictionaries composed by the `name`, `size` and
@@ -453,6 +454,7 @@ def list_files(workflow, access_token, page=None, size=None):
         (response, http_response) = current_rs_api_client.api.get_files(
             workflow_id_or_name=workflow,
             access_token=access_token,
+            file_name=file_name,
             page=page,
             size=size,
         ).result()

--- a/reana_client/cli/files.py
+++ b/reana_client/cli/files.py
@@ -66,21 +66,24 @@ def files_group(ctx):
     default=None,
     help="Get URLs of output files.",
 )
+@click.argument("filename", metavar="SOURCE", nargs=1, required=False)
 @add_access_token_options
 @add_pagination_options
 @click.pass_context
 def get_files(
-    ctx, workflow, _filter, output_format, access_token, page, size
+    ctx, workflow, _filter, output_format, filename, access_token, page, size
 ):  # noqa: D301
     """List workspace files.
 
     The `ls` command lists workspace files of a workflow specified by the
     environment variable REANA_WORKON or provided as a command-line flag
-    `--workflow` or `-w`.
+    `--workflow` or `-w`. The SOURCE argument is optional and specifies a
+    pattern matching files and directories.
 
     Examples: \n
-    \t $ reana-client ls --workflow myanalysis.42
-    """
+    \t $ reana-client ls --workflow myanalysis.42 \n
+    \t $ reana-client ls --workflow myanalysis.42 'code/\*'
+    """  # noqa: W605
     import tablib
     from reana_client.api.client import current_rs_api_client, list_files
 
@@ -93,7 +96,7 @@ def get_files(
     if workflow:
         logging.info('Workflow "{}" selected'.format(workflow))
         try:
-            response = list_files(workflow, access_token, page, size)
+            response = list_files(workflow, access_token, filename, page, size)
             headers = ["name", "size", "last-modified"]
             data = []
             file_path = get_path_from_operation_id(

--- a/reana_client/cli/files.py
+++ b/reana_client/cli/files.py
@@ -194,7 +194,9 @@ def download_files(
     if workflow:
         for file_name in filenames:
             try:
-                binary_file = download_file(workflow, file_name, access_token)
+                binary_file, file_name = download_file(
+                    workflow, file_name, access_token
+                )
 
                 logging.info(
                     "{0} binary file downloaded ... writing to {1}".format(

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ install_requires = [
     'cwl-utils==0.5 ; python_version>="3"',
     "pyOpenSSL>=19.0.0",  # FIXME remove once yadage-schemas solves deps.
     "jsonpointer>=2.0",
-    "reana-commons>=0.7.4,<0.8.0",
+    "reana-commons>=0.7.5a1,<0.8.0",
     "rfc3987>=1.3.8",  # FIXME remove once yadage-schemas solves deps.
     "six==1.12.0",
     "strict-rfc3339>=0.7",  # FIXME remove once yadage-schemas solves deps.

--- a/tests/test_cli_files.py
+++ b/tests/test_cli_files.py
@@ -93,15 +93,18 @@ def test_download_file():
     status_code = 200
     response = "Content of file to download"
     env = {"REANA_SERVER_URL": "localhost"}
+    file = "dummy_file.txt"
     mock_http_response = Mock()
     mock_http_response.status_code = status_code
     mock_http_response.content = str(response).encode()
+    mock_http_response.headers = {
+        "Content-Disposition": "attachment; filename={}".format(file)
+    }
     mock_requests = Mock()
     mock_requests.get = Mock(return_value=mock_http_response)
 
     reana_token = "000000"
     response_md5 = hashlib.md5(response.encode("utf-8")).hexdigest()
-    file = "dummy_file.txt"
     message = "File {0} downloaded to".format(file)
     runner = CliRunner(env=env)
     with runner.isolation():


### PR DESCRIPTION
Depends on https://github.com/reanahub/reana-client/pull/483

Needs `r-commons` release to pass - https://github.com/reanahub/reana-commons/pull/253

closes #402


#### To test
- Create a workflow
- Upload multiple files in multiple levels of directories
- Try to download different directories by name
- Try to download multiple files by passing glob patterns

Pseudo-example
```console
$ reana-client download -w workflow 'mydir'
$ reana-client download -w workflow '**/*.py'
$ reana-client download -w workflow '**/*.txt'
$ reana-client download -w workflow 'mydir/foo/*.py'
...
```
If it the pattern matches more than one file, you should get a zip downloaded, otherwise a single file.


#### TBD

When downloading a single file,  until now, the path where this file is in the workspace is respected locally. This is because the file is saved directly using the value that is passed to the command as an argument. E.g. `reana-client download -w workflow foo/bar/myfile.txt` would create directories `foo/bar` for you as it uses this argument to save the file.

After this PR, since the argument can be a glob pattern, we get the filename from the server-side and save it as it is, thus, causing the path where the file is not to be respected. This is done this way because otherwise, one might end up having folders called `\*\*` or similar. E.g. `reana-client download -w workflow '**/myfile.txt'` would create a dir called `\*\*` and put `myfile.txt` inside.

**Update 19/04/2021**: It is possible to pass `attachment_filename` arg to `send_from_directory` so one can customize the content of `filename` in the `Content-Disposition` header. Passing there a relative path allows us to keep the folder structure and be backwards compatible. Updated on https://github.com/reanahub/reana-workflow-controller/pull/369/files