### PR TITLE
validate: map steps in yadage parameter validation

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -283,6 +283,13 @@ def yadage_workflow_spec_loaded():
                                             "scheduler_type": "singlestep-stage",
                                             "parameters": [
                                                 {
+                                                    "key": "nested_foo",
+                                                    "value": {
+                                                        "step": "init",
+                                                        "output": "nested_foo",
+                                                    },
+                                                },
+                                                {
                                                     "key": "inputs",
                                                     "value": {
                                                         "stages": "run_mc[*].mergeallvars",

--- a/tests/test_validate_parameters.py
+++ b/tests/test_validate_parameters.py
@@ -158,7 +158,8 @@ def test_validate_parameters_yadage(yadage_workflow_spec_loaded, capsys):
     _validate_yadage_parameters(reana_yaml)
     captured = capsys.readouterr()
     assert (
-        'WARNING: Yadage input parameter "qux" does not seem to be used' in captured.out
+        'WARNING: Yadage input parameter "qux" found on step "gendata" does not seem to be used.'
+        in captured.out
     )
     reana_yaml["workflow"]["specification"]["stages"][0]["scheduler"][
         "parameters"
@@ -197,7 +198,7 @@ def test_validate_parameters_yadage(yadage_workflow_spec_loaded, capsys):
     _validate_yadage_parameters(reana_yaml)
     captured = capsys.readouterr()
     assert (
-        'WARNING: Yadage input parameter "subfoo" does not seem to be used'
+        'WARNING: Yadage input parameter "subfoo" found on step "nested_step" does not seem to be used.'
         in captured.out
     )
 
@@ -215,6 +216,18 @@ def test_validate_parameters_yadage(yadage_workflow_spec_loaded, capsys):
     captured = capsys.readouterr()
     assert (
         'WARNING: Yadage parameter "subbar" found on step "nested_step" is not defined in input parameters'
+        in captured.out
+    )
+
+    # Parameter defined in one stage, but forgotten in the other one
+    process = reana_yaml["workflow"]["specification"]["stages"][1]["scheduler"]["step"][
+        "process"
+    ]
+    process["script"] += " && ./run-job {foo}"
+    _validate_yadage_parameters(reana_yaml)
+    captured = capsys.readouterr()
+    assert (
+        'WARNING: Yadage parameter "foo" found on step "fitdata" is not defined in input parameters.'
         in captured.out
     )
 


### PR DESCRIPTION
Fixes user [reported issue](https://forum.reana.io/t/validation-does-not-fail-when-a-parameter-is-used-in-two-stages-but-is-defined-in-the-first-one-and-is-not-defined-in-the-second-one/41):
`Validation does not fail when a parameter is used in two stages but is defined in the first one and is not defined in the second one`

To reproduce the issue and test on `reana-demo-root6-roofit` example:
- Add `myPar: 1` in [reana spec](https://github.com/reanahub/reana-demo-root6-roofit/blob/master/reana-yadage.yaml#L11)
- Define `myPar` in [`gendata` stage](https://github.com/reanahub/reana-demo-root6-roofit/blob/master/workflow/yadage/workflow.yaml#L23): ```myPar: {step: init, output: myPar}```
- Use it in [`gendata` stage](https://github.com/reanahub/reana-demo-root6-roofit/blob/master/workflow/yadage/workflow.yaml#L27): ```script: root -b -q '{gendata}{myPar}({events},"{outfilename}")'```
- Try to use it in [`fitdata` stage](https://github.com/reanahub/reana-demo-root6-roofit/blob/master/workflow/yadage/workflow.yaml#L47): ```script: root -b -q '{fitdata}{myPar}("{data}","{outfile}")'```

Old code should not produce the warning in this case, new one should:

```console
reana-client ❯ reana-client validate -f ./reana-yadage.yaml
==> Verifying REANA specification file... /home/amecioni/Documents/projects/reana-demo-root6-roofit/reana-yadage.yaml
  -> SUCCESS: Valid REANA specification file.
==> Verifying workflow parameters and commands...
  -> WARNING: Yadage parameter "myPar" found on step "fitdata" is not defined in input parameters.
```


