### PR TITLE
cli: add start and finish time to job logs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Version 0.8.0 (UNRELEASED)
 
 - Adds new command ``quota-show``.
 - Adds possibility to filter by workflow status and search by workflow name to ``list``.
+- Adds job start and finish times to ``logs`` command output.
 - Changes ``delete`` to prevent workflow hard deletion.
 - Changes ``list`` to display interactive session status.
 

--- a/reana_client/cli/utils.py
+++ b/reana_client/cli/utils.py
@@ -297,6 +297,8 @@ def output_user_friendly_logs(workflow_logs, steps):
         "docker_img": "Docker image",
         "cmd": "Command",
         "status": "Status",
+        "started_at": "Started",
+        "finished_at": "Finished",
     }
     leading_mark = "==>"
 
@@ -345,13 +347,15 @@ def output_user_friendly_logs(workflow_logs, steps):
             del logs_info["job_name"]
 
             for key, value in logs_info.items():
-                title = click.style(
-                    "{mark} {description}:".format(
-                        mark=leading_mark, description=key_to_description_mapping[key]
-                    ),
-                    fg=status_to_color_mapping.get(logs_info["status"]),
-                )
-                click.secho("{title} {value}".format(title=title, value=value))
+                if value:
+                    title = click.style(
+                        "{mark} {description}:".format(
+                            mark=leading_mark,
+                            description=key_to_description_mapping[key],
+                        ),
+                        fg=status_to_color_mapping.get(logs_info["status"]),
+                    )
+                    click.secho("{title} {value}".format(title=title, value=value))
             # show actual log content
             if logs_output:
                 click.secho(


### PR DESCRIPTION
Closes #497.

To test:

1. Create a workflow and add some more steps with sleeps, e.g. `reana-demo-helloworld`
```diff
diff --git a/reana.yaml b/reana.yaml
index 50d1bd8..d243815 100644
--- a/reana.yaml
+++ b/reana.yaml
@@ -18,6 +18,12 @@ workflow:
               --inputfile "${inputfile}"
               --outputfile "${outputfile}"
               --sleeptime ${sleeptime}
+      - environment: 'python:2.7-slim'
+        commands:
+          - sleep 5
+      - environment: 'python:2.7-slim'
+        commands:
+          - sleep 20
 outputs:
   files:
    - results/greetings.txt
```
2. Observe `reana-client logs -w workflow-name`
