### PR TITLE
dag: estimate initial workflow complexity for Yadage workflows

### DIFF
--- a/reana_client/utils.py
+++ b/reana_client/utils.py
@@ -34,6 +34,7 @@ from reana_client.config import (
 from reana_client.printer import display_message
 from reana_client.validation.environments import validate_environment
 from reana_client.validation.parameters import validate_parameters
+from reana_client.validation.complexity import estimate_complexity
 
 
 def workflow_uuid_or_name(ctx, param, value):
@@ -161,14 +162,15 @@ def load_reana_spec(
         )
 
         if not skip_validation:
-            display_message(
-                "Verifying REANA specification file... {filepath}".format(
-                    filepath=filepath
-                ),
-                msg_type="info",
-            )
-            _validate_reana_yaml(reana_yaml)
-            validate_parameters(workflow_type, reana_yaml)
+            # display_message(
+            #     "Verifying REANA specification file... {filepath}".format(
+            #         filepath=filepath
+            #     ),
+            #     msg_type="info",
+            # )
+            # _validate_reana_yaml(reana_yaml)
+            # validate_parameters(workflow_type, reana_yaml)
+            estimate_complexity(workflow_type, reana_yaml)
 
         if not skip_validate_environments:
             display_message(

--- a/reana_client/validation/complexity.py
+++ b/reana_client/validation/complexity.py
@@ -1,0 +1,215 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of REANA.
+# Copyright (C) 2021 CERN.
+#
+# REANA is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""REANA workflow complexity estimation."""
+
+import os
+
+from reana_client.printer import display_message
+
+
+def estimate_complexity(workflow_type, reana_yaml):
+    """Estimate complexity in REANA workflow.
+
+    :param workflow_type: A supported workflow specification type.
+    :param reana_yaml: REANA YAML specification.
+    """
+
+    def build_estimator(workflow_type, reana_yaml):
+        if workflow_type == "serial":
+            return SerialComplexityEstimator(reana_yaml)
+        elif workflow_type == "yadage":
+            return YadageComplexityEstimator(reana_yaml)
+        elif workflow_type == "cwl":
+            return CWLComplexityEstimator(reana_yaml)
+        else:
+            raise Exception(
+                "Workflow type '{0}' is not supported".format(workflow_type)
+            )
+
+    estimator = build_estimator(workflow_type, reana_yaml)
+    complexity = estimator.estimate_complexity()
+
+    display_message(
+        "Estimated workflow complexity: \n{0}".format(complexity),
+        msg_type="info",
+        indented=True,
+    )
+
+
+class ComplexityEstimatorBase:
+    """REANA workflow complexity estimator base class."""
+
+    def __init__(self, reana_yaml):
+        """Estimate complexity in REANA workflow.
+
+        :param reana_yaml: REANA YAML specification.
+        :param initial_step: initial workflow execution step.
+        """
+        self.reana_yaml = reana_yaml
+        self.specification = reana_yaml.get("workflow", {}).get("specification", {})
+        self.input_params = reana_yaml.get("inputs", {}).get("parameters", {})
+
+    def parse_specification(self, initial_step):
+        """Parse REANA workflow specification tree."""
+        raise NotImplementedError
+
+    def estimate_complexity(self, initial_step="init"):
+        """Estimate complexity in parsed REANA workflow tree."""
+        steps = self.parse_specification(initial_step)
+        return self._calculate_complexity(steps)
+
+    def _calculate_complexity(self, steps):
+        """Calculate complexity in parsed REANA workflow tree."""
+        complexity = []
+        for step in steps.values():
+            complexity += step["complexity"]
+        return complexity
+
+
+class SerialComplexityEstimator(ComplexityEstimatorBase):
+    """REANA serial workflow complexity estimation."""
+
+    def parse_specification(self, initial_step):
+        """Parse serial workflow specification tree."""
+        return {}
+
+
+class YadageComplexityEstimator(ComplexityEstimatorBase):
+    """REANA Yadage workflow complexity estimation."""
+
+    def _parse_steps(self, stages, initial_step):
+        """Parse and filter out Yadage workflow tree."""
+
+        def _is_initial_stage(stage):
+            dependencies = stage.get("dependencies", {}).get("expressions", [])
+
+            if dependencies == [initial_step]:
+                return True
+
+            if initial_step == "init":
+                # Not defined dependencies should be treated as `init`
+                return not dependencies
+            return False
+
+        def _get_memory_limit(stage):
+            # TODO: convert memory limit value to bytes (`kubernetes_memory_to_bytes`)
+            # TODO: validate memory limit value. Reuse code from (`set_memory_limit` in RJC)
+            # TODO: get `default_memory_limit` from config
+            resources = (
+                stage.get("scheduler", {})
+                .get("step", {})
+                .get("environment", {})
+                .get("resources", [])
+            )
+            default_memory_limit = os.getenv(
+                "REANA_KUBERNETES_JOBS_MEMORY_LIMIT", "8Gi"
+            )
+            return next(
+                filter(lambda r: "kubernetes_memory_limit" in r.keys(), resources), {},
+            ).get("kubernetes_memory_limit", default_memory_limit)
+
+        def _parse_stages(stages):
+            tree = {}
+            for stage in stages:
+                if not _is_initial_stage(stage):
+                    continue
+                name = stage["name"]
+                scheduler = stage.get("scheduler", {})
+                parameters = scheduler.get("parameters", [])
+                tree[name] = {"params": parameters, "stages": {}, "scatter_params": []}
+
+                # Parse memory limit
+                tree[name]["memory_limit"] = _get_memory_limit(stage)
+
+                # Parse nested stages
+                if "workflow" in scheduler:
+                    nested_stages = scheduler["workflow"].get("stages", [])
+                    parsed_stages = _parse_stages(nested_stages)
+                    tree[name]["stages"].update(parsed_stages)
+
+                # Parse scatter parameters
+                if "scatter" in scheduler and scheduler["scatter"]["method"] == "zip":
+                    tree[name]["scatter_params"] = scheduler["scatter"]["parameters"]
+
+            return tree
+
+        return _parse_stages(stages)
+
+    def _populate_parameters(self, stages, parent_params):
+        """Populate parsed Yadage workflow tree with parameter values."""
+
+        def _parse_params(stage, parent_params):
+            parent_params = parent_params.copy()
+            for param in stage["params"]:
+                if isinstance(param["value"], list):
+                    parent_params[param["key"]] = param["value"]
+                elif isinstance(param["value"], dict):
+                    # Example: input_file: {step: init, output: files}
+                    # In this case `files` values should be taken from
+                    # `parent_params` and saved as `input_file`
+                    output = param["value"].get("output", "")
+                    parent_value = parent_params.get(output, "")
+                    parent_params[param["key"]] = parent_value
+                else:
+                    parent_params[param["key"]] = [param["value"]]
+            return parent_params
+
+        def _parse_stages(stages, parent_params):
+            stages = stages.copy()
+            for stage in stages.keys():
+                stage_value = stages[stage]
+                # Handle params
+                params = _parse_params(stage_value, parent_params)
+                stage_value["params"] = params
+                # Handle nested stages
+                stage_value["stages"] = _parse_stages(stage_value["stages"], params)
+            return stages
+
+        return _parse_stages(stages, parent_params)
+
+    def _populate_complexity(self, stages):
+        """Calculate number of jobs and memory needed for the parsed Yadage workflow tree."""
+
+        def _parse_stages(stages):
+            stages = stages.copy()
+            for stage in stages.keys():
+                stage_value = stages[stage]
+                complexity = [(1, stage_value["memory_limit"])]
+
+                # Handle nested stages
+                parsed_stages = _parse_stages(stage_value["stages"])
+                stage_value["stages"] = parsed_stages
+                if parsed_stages:
+                    complexity = self._calculate_complexity(parsed_stages)
+
+                # Handle scatter parameters
+                if stage_value["scatter_params"]:
+                    first_param = stage_value["scatter_params"][0]
+                    param_len = len(stage_value["params"].get(first_param, []))
+                    complexity = [(item[0] * param_len, item[1]) for item in complexity]
+
+                stage_value["complexity"] = complexity
+            return stages
+
+        return _parse_stages(stages)
+
+    def parse_specification(self, initial_step):
+        """Parse Yadage workflow specification tree."""
+        steps = self._parse_steps(self.specification["stages"], initial_step)
+        steps = self._populate_parameters(steps, self.input_params)
+        steps = self._populate_complexity(steps)
+        return steps
+
+
+class CWLComplexityEstimator(ComplexityEstimatorBase):
+    """REANA CWL workflow complexity estimation."""
+
+    def parse_specification(self, initial_step):
+        """Parse CWL workflow specification tree."""
+        return {}


### PR DESCRIPTION
closes https://github.com/reanahub/reana-server/issues/360

**NOTE**: this PR is included into https://github.com/reanahub/reana-server/pull/366

This PR adds Yadage workflow complexity estimator, which tries to:
- parse the workflow tree to filter out initial stages which will be launched on execution. Note that by default it's looking for `init` dependency, but some other can be passed down to constructor as `initial_step` value.
- It constructs internal representation of filtered tree which holds: `name, parameters, nested stages, memory limit, scatter parameters`
- As a second step it tries to populate the input parameters down the tree starting from the top. Also handles these kind of cases: `input_file: {step: init, output: files}` where `files` value should be taken from parent stage and used as `input_file`
- Third step is to calculate the complexity of the workflow taking into account scatter parameters and nested stages.

For bsm search example it should return the following:
```console
~/Documents/projects/reana-demo-bsm-search master*
reana ❯ rc validate
  -> INFO: Estimated workflow complexity:
[(8, '8Gi'), (5, '8Gi'), (2, '8Gi')]
```