### PR TITLE
setup: upper pin `ruamel.yaml.clib` for py2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,18 +42,19 @@ setup_requires = [
 ]
 
 install_requires = [
-    "PyYAML>=5.1",
-    'typing>=3.7.4 ; python_version=="2.7"',  # workaround for CWL deps
     'click>=7 ; python_version>="3"',
     'click==7.0 ; python_version=="2.7"',
     "cwltool==1.0.20191022103248",
     'cwl-utils==0.5 ; python_version>="3"',
     "jsonpointer>=2.0",
+    "PyYAML>=5.1",
     "reana-commons[yadage]>=0.8.0a17,<0.9.0",
+    'ruamel.yaml.clib==0.2.2 ; python_version=="2.7"',  # pin due to py2 support drop
     "six>=1.12.0",
     "tablib>=0.12.1,<0.13",
-    "werkzeug>=0.14.1",
+    'typing>=3.7.4 ; python_version=="2.7"',  # workaround for CWL deps
     'websocket-client==0.59.0 ; python_version=="2.7"',  # pin due to py2 support drop
+    "werkzeug>=0.14.1",
 ]
 
 packages = find_packages()


### PR DESCRIPTION
Due to dropping python 2 support in version 0.2.4
https://pypi.org/project/ruamel.yaml.clib/0.2.4/

Build logs with current master: https://github.com/mvidalgarcia/reana-client/runs/2912479360?check_suite_focus=true


```
Collecting ruamel.yaml.clib==0.2.4                                                                                                                                                                                                                            
  Downloading ruamel.yaml.clib-0.2.4.tar.gz (180 kB)                                                                                                                                                                                                          
     |████████████████████████████████| 180 kB 3.7 MB/s                                                                                                                                                                                                       
    ERROR: Command errored out with exit status 1:                                                                                                                                                                                                            
     command: /Users/marco/.virtualenvs/r-client-py2/bin/python -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/private/var/folders/cg/813_2zs10ss_j0gl_w708fxw0000gn/T/pip-install-wcVAdD/ruamel-yaml-clib/setup.py'"'"'; __file__='"'"'/private/va
r/folders/cg/813_2zs10ss_j0gl_w708fxw0000gn/T/pip-install-wcVAdD/ruamel-yaml-clib/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"')
)' egg_info --egg-base /private/var/folders/cg/813_2zs10ss_j0gl_w708fxw0000gn/T/pip-pip-egg-info-HIOb3C                                                                                                                                                       
         cwd: /private/var/folders/cg/813_2zs10ss_j0gl_w708fxw0000gn/T/pip-install-wcVAdD/ruamel-yaml-clib/                                                                                                                                                   
    Complete output (1 lines):                                                                                                                                                                                                                                
    minimum python version(s): [(3, 5)]                                                                                                                                                                                                                       
    ----------------------------------------                                                                                                                                                                                                                  
ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.       
```