### PR TITLE
snakemake: load reana spec to send it to server

### DIFF
--- a/reana_client/api/client.py
+++ b/reana_client/api/client.py
@@ -16,10 +16,11 @@ from functools import partial
 
 import requests
 from bravado.exception import HTTPError
-from reana_client.config import ERROR_MESSAGES, WORKFLOW_ENGINES
+from reana_client.config import ERROR_MESSAGES
 from reana_client.errors import FileDeletionError, FileUploadError
 from reana_client.utils import _validate_reana_yaml, is_uuid_v4
 from reana_commons.api_client import get_current_api_client
+from reana_commons.config import REANA_WORKFLOW_ENGINES
 from reana_commons.errors import REANASecretAlreadyExists, REANASecretDoesNotExist
 from werkzeug.local import LocalProxy
 
@@ -233,10 +234,10 @@ def create_workflow_from_json(
     if os.environ.get("REANA_SERVER_URL") is None:
         raise Exception("Environment variable REANA_SERVER_URL is not set")
     workflow_engine = workflow_engine.lower()
-    if workflow_engine not in WORKFLOW_ENGINES:
+    if workflow_engine not in REANA_WORKFLOW_ENGINES:
         raise Exception(
             "Workflow engine - {} not found. You must use one of "
-            "these engines - {}".format(workflow_engine, WORKFLOW_ENGINES)
+            "these engines - {}".format(workflow_engine, REANA_WORKFLOW_ENGINES)
         )
     try:
         reana_yaml = dict(workflow={})

--- a/reana_client/cli/workflow.py
+++ b/reana_client/cli/workflow.py
@@ -934,7 +934,7 @@ def workflow_validate(ctx, file, environments, pull):  # noqa: D301
             pull_environment_image=pull,
         )
 
-    except ValidationError as e:
+    except (ValidationError, REANAValidationError) as e:
         logging.debug(traceback.format_exc())
         logging.debug(str(e))
         display_message(

--- a/reana_client/config.py
+++ b/reana_client/config.py
@@ -37,9 +37,6 @@ TIMECHECK = 5
 URL = "url"
 """Url output format."""
 
-WORKFLOW_ENGINES = ["serial", "cwl", "yadage", "snakemake"]
-"""Supported workflow engines."""
-
 RUN_STATUSES = [
     "created",
     "running",

--- a/reana_client/config.py
+++ b/reana_client/config.py
@@ -37,7 +37,7 @@ TIMECHECK = 5
 URL = "url"
 """Url output format."""
 
-WORKFLOW_ENGINES = ["serial", "cwl", "yadage"]
+WORKFLOW_ENGINES = ["serial", "cwl", "yadage", "snakemake"]
 """Supported workflow engines."""
 
 RUN_STATUSES = [

--- a/reana_client/validation/parameters.py
+++ b/reana_client/validation/parameters.py
@@ -33,6 +33,8 @@ def validate_parameters(workflow_type, reana_yaml):
             return YadageParameterValidator(reana_yaml)
         if workflow_type == "cwl":
             return CWLParameterValidator(reana_yaml)
+        if workflow_type == "snakemake":
+            return SnakemakeParameterValidator(reana_yaml)
 
     validator = build_validator(workflow_type, reana_yaml)
     validator.validate()
@@ -448,3 +450,15 @@ class CWLParameterValidator(ParameterValidatorBase):
         elif isinstance(workflow, list):
             for wf in workflow:
                 _check_dangerous_operations(wf)
+
+
+class SnakemakeParameterValidator(ParameterValidatorBase):
+    """REANA Snakemake workflow parameter validation."""
+
+    def validate_parameters(self):
+        """Validate input parameters for Snakemake workflows."""
+        pass
+
+    def parse_specification(self):
+        """Parse Snakemake workflow tree."""
+        pass

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ install_requires = [
     "cwl-utils==0.5",
     "jsonpointer>=2.0",
     "PyYAML>=5.1",
-    "reana-commons[yadage]>=0.8.0a19,<0.9.0",
+    "reana-commons[yadage,snakemake]>=0.8.0a19,<0.9.0",
     "six>=1.12.0",
     "tablib>=0.12.1,<0.13",
     "werkzeug>=0.14.1",

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ install_requires = [
     "cwl-utils==0.5",
     "jsonpointer>=2.0",
     "PyYAML>=5.1",
-    "reana-commons[yadage,snakemake]>=0.8.0a19,<0.9.0",
+    "reana-commons[yadage,snakemake]>=0.8.0a20,<0.9.0",
     "six>=1.12.0",
     "tablib>=0.12.1,<0.13",
     "werkzeug>=0.14.1",


### PR DESCRIPTION
closes #531

```console
$ reana-client create -f reana-snakemake.yaml -w helloworld-snakemake
$ reana-client upload -w helloworld-snakemake
$ reana-client start -w helloworld-snakemake
$ reana-client logs -w helloworld-snakemake                       
==> Workflow engine logs
2021-07-22 09:16:27,199 | reana-workflow-engine-snakemake | MainThread | INFO | Snakemake workflows are not yet supported. Skipping...
2021-07-22 09:16:27,199 | reana-workflow-engine-snakemake | MainThread | INFO | Workflow spec received: workflow/snakemake/Snakefile
2021-07-22 09:16:27,211 | root | MainThread | INFO | Workflow 1d297776-64de-4ee9-8e32-78b34cbe45b4 finished. Files available at users/00000000-0000-0000-0000-000000000000/workflows/1d297776-64de-4ee9-8e32-78b34cbe45b4.
```