### PR TITLE
reana.yaml: add support for outputs.directories

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,10 @@
 Changes
 =======
 
+Version 0.7.6 (UNRELEASED)
+--------------------------
+- Adds support for ``outputs.directories`` in ``reana.yaml``
+
 Version 0.7.5 (2021-07-05)
 --------------------------
 

--- a/reana_client/cli/files.py
+++ b/reana_client/cli/files.py
@@ -171,10 +171,10 @@ def download_files(
 ):  # noqa: D301
     """Download workspace files.
 
-    The `download` command allows to download workspace files. By default, the
-    files specified in the workflow specification as outputs are downloaded.
-    You can also specify the individual files you would like to download, see
-    examples below. Note that downloading directories is not yet supported.
+    The `download` command allows to download workspace files and directories.
+    By default, the files specified in the workflow specification as outputs
+    are downloaded. You can also specify the individual files you would like
+    to download, see examples below.
 
     Examples: \n
     \t $ reana-client download # download all output files \n
@@ -189,7 +189,9 @@ def download_files(
     if not filenames:
         reana_spec = get_workflow_specification(workflow, access_token)["specification"]
         if "outputs" in reana_spec:
-            filenames = reana_spec["outputs"].get("files") or []
+            filenames = []
+            filenames += reana_spec["outputs"].get("files", [])
+            filenames += reana_spec["outputs"].get("directories", [])
 
     if workflow:
         for file_name in filenames:

--- a/reana_client/schemas/reana_analysis_schema.json
+++ b/reana_client/schemas/reana_analysis_schema.json
@@ -64,12 +64,25 @@
         "files": {
           "id": "/properties/outputs/properties/files",
           "type": "array",
-          "title": "Analysis results.",
+          "title": "Analysis result files.",
           "description": "Expected output from analysis represented by a set of files.",
+          "optional": true,
           "items": {
             "id": "/properties/outputs/properties/files/items",
             "type": "string",
             "title": "Relative path to the file."
+          }
+        },
+        "directories": {
+          "id": "/properties/outputs/properties/directories",
+          "type": "array",
+          "title": "Analysis result directories.",
+          "description": "Expected output from analysis represented by a set of directories.",
+          "optional": true,
+          "items": {
+            "id": "/properties/outputs/properties/directories/items",
+            "type": "string",
+            "title": "Relative path to the directory."
           }
         }
       }


### PR DESCRIPTION
closes https://github.com/reanahub/reana-client/issues/536

Tested `roofit` demo with:
```yaml
outputs:
  files:
    - results/data.root
    - results/plot.png
  directories:
    - results
    - code
```
result:
```yaml
- results/data.root
- results/plot.png
- download_roofit.1_code_2021-07-12-100149.zip
- download_roofit.1_results_2021-07-12-100148.zip
```