### PR TITLE
snakemake: add environment validation

### DIFF
--- a/reana_client/api/client.py
+++ b/reana_client/api/client.py
@@ -13,6 +13,7 @@ import logging
 import os
 import traceback
 from functools import partial
+from urllib.parse import urljoin
 
 import requests
 from bravado.exception import HTTPError
@@ -23,11 +24,6 @@ from reana_commons.api_client import get_current_api_client
 from reana_commons.config import REANA_WORKFLOW_ENGINES
 from reana_commons.errors import REANASecretAlreadyExists, REANASecretDoesNotExist
 from werkzeug.local import LocalProxy
-
-try:
-    from urllib.parse import urljoin
-except ImportError:
-    from urlparse import urljoin
 
 current_rs_api_client = LocalProxy(
     partial(get_current_api_client, component="reana-server")

--- a/reana_client/validation/environments.py
+++ b/reana_client/validation/environments.py
@@ -43,6 +43,11 @@ def validate_environment(reana_yaml, pull=False):
         if workflow_type == "cwl":
             workflow_file = workflow.get("file")
             return CWLEnvironmentValidator(workflow_file=workflow_file, pull=pull)
+        if workflow_type == "snakemake":
+            workflow_steps = workflow["specification"]["steps"]
+            return SnakemakeEnvironmentValidator(
+                workflow_steps=workflow_steps, pull=pull
+            )
 
     workflow = reana_yaml["workflow"]
     validator = build_validator(workflow)
@@ -471,3 +476,14 @@ class CWLEnvironmentValidator(EnvironmentValidatorBase):
 
         for image in traverse(top):
             self._validate_environment_image(image)
+
+
+class SnakemakeEnvironmentValidator(EnvironmentValidatorBase):
+    """REANA Snakemake workflow environments validation."""
+
+    def validate_environment(self):
+        """Validate environments in REANA Snakemake workflow."""
+        for step in self.workflow_steps:
+            image = step["environment"]
+            kubernetes_uid = step.get("kubernetes_uid")
+            self._validate_environment_image(image, kubernetes_uid=kubernetes_uid)

--- a/reana_client/validation/environments.py
+++ b/reana_client/validation/environments.py
@@ -460,17 +460,8 @@ class CWLEnvironmentValidator(EnvironmentValidatorBase):
 
     def validate_environment(self):
         """Validate environments in REANA CWL workflow."""
-
-        try:
-            import cwl_utils.parser_v1_0 as cwl_parser
-            from cwl_utils.docker_extract import traverse
-        except ImportError as e:
-            display_message(
-                "Cannot validate environment. Please install reana-client on Python 3+ to enable environment validation for CWL workflows.",
-                msg_type="error",
-                indented=True,
-            )
-            raise e
+        import cwl_utils.parser_v1_0 as cwl_parser
+        from cwl_utils.docker_extract import traverse
 
         top = cwl_parser.load_document(self.workflow_file)
 

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ install_requires = [
     "cwl-utils==0.5",
     "jsonpointer>=2.0",
     "PyYAML>=5.1",
-    "reana-commons[yadage,snakemake]>=0.8.0a20,<0.9.0",
+    "reana-commons[yadage,snakemake]>=0.8.0a22,<0.9.0",
     "six>=1.12.0",
     "tablib>=0.12.1,<0.13",
     "werkzeug>=0.14.1",


### PR DESCRIPTION
closes #540

Supersedes https://github.com/reanahub/reana-client/pull/542

#### To test
```console
$ cd ../reana-demo-root6-roofit   # test also helloworld & worldpopulation
$ reana-client validate --environments -f reana-snakemake.yaml --pull
==> Verifying REANA specification file... /Users/marco/code/reanahub/reana-demo-root6-roofit/reana-snakemake.yaml
  -> SUCCESS: Valid REANA specification file.
==> Verifying REANA specification parameters... 
  -> SUCCESS: REANA specification parameters appear valid.
==> Verifying workflow parameters and commands... 
  -> SUCCESS: Workflow parameters and commands appear valid.
==> Verifying dangerous workflow operations... 
  -> SUCCESS: Workflow operations appear valid.
==> Verifying environments in REANA specification file...
  -> SUCCESS: Environment image reanahub/reana-env-root6:6.18.04 has the correct format.
  -> SUCCESS: Environment image reanahub/reana-env-root6:6.18.04 exists locally.
  -> SUCCESS: Environment image reanahub/reana-env-root6:6.18.04 exists in Docker Hub.
  -> INFO: Environment image uses UID 0 but will run as UID 1000.
```