### PR TITLE
snakemake: add parameter & dangerous ops validation

### DIFF
--- a/reana_client/utils.py
+++ b/reana_client/utils.py
@@ -131,6 +131,14 @@ def load_reana_spec(
             **_prepare_kwargs(reana_yaml)
         )
 
+        if (
+            workflow_type == "cwl" or workflow_type == "snakemake"
+        ) and "inputs" in reana_yaml:
+            with open(reana_yaml["inputs"]["parameters"]["input"]) as f:
+                reana_yaml["inputs"]["parameters"] = yaml.load(
+                    f, Loader=yaml.FullLoader
+                )
+
         if not skip_validation:
             display_message(
                 "Verifying REANA specification file... {filepath}".format(
@@ -147,14 +155,6 @@ def load_reana_spec(
                 msg_type="info",
             )
             validate_environment(reana_yaml, pull=pull_environment_image)
-
-        if (
-            workflow_type == "cwl" or workflow_type == "snakemake"
-        ) and "inputs" in reana_yaml:
-            with open(reana_yaml["inputs"]["parameters"]["input"]) as f:
-                reana_yaml["inputs"]["parameters"] = yaml.load(
-                    f, Loader=yaml.FullLoader
-                )
 
         if workflow_type == "yadage":
             # We don't send the loaded Yadage workflow spec to the cluster as


### PR DESCRIPTION
closes #543
closes #544

To test:
- Parameters:
  1. Add/remove `params`, `input` or `output` in the Snakefile.
  2. Include non-existing references of `params`, `input` or `output` to the shell commands, e.g. `{params.foo}`, `{input.bar}`...
  3. Run `reana-client validate -f reana-snakemake.yaml` and verify that warnings are there.
- Dangerous ops:
  - Add `cd /` or `sudo` to the shell commands in the Snakefile.
Example output:
```console
==> Verifying REANA specification file... /Users/marco/code/reanahub/reana-demo-worldpopulation/reana-snakemake.yaml
  -> SUCCESS: Valid REANA specification file.
==> Verifying REANA specification parameters... 
  -> SUCCESS: REANA specification parameters appear valid.
==> Verifying workflow parameters and commands... 
  -> WARNING: Snakemake parameter "bar" found on step "worldpopulation" is not defined in input parameters.
  -> WARNING: Snakemake input parameter "foo" found on step "worldpopulation" does not seem to be used.
==> Verifying dangerous workflow operations... 
  -> WARNING: Operation "sudo" found in step "worldpopulation" might be dangerous.
  ```

