### PR TITLE
cwl: remove legacy Python2 support

### DIFF
--- a/reana_client/cli/cwl_runner.py
+++ b/reana_client/cli/cwl_runner.py
@@ -27,8 +27,6 @@ from reana_client.config import default_user
 from reana_client.utils import load_workflow_spec
 from reana_client.version import __version__
 
-PY3 = sys.version_info > (3,)
-
 
 def findfiles(wo, fn=None):
     """Return a list CWL workflow files."""
@@ -58,7 +56,7 @@ def get_file_dependencies_obj(cwl_obj, basedir):
     # remove filename additions (e.g. 'v1.0/conflict-wf.cwl#collision')
     document = cwl_obj.split("#")[0]
     document_loader, workflow_obj, uri = fetch_document(document)
-    in_memory_buffer = io.StringIO() if PY3 else io.BytesIO()
+    in_memory_buffer = io.StringIO()
     # Get dependencies
     printdeps(
         workflow_obj,

--- a/reana_client/cli/cwl_runner.py
+++ b/reana_client/cli/cwl_runner.py
@@ -13,7 +13,6 @@ import os
 import re
 import sys
 import traceback
-import urllib
 from time import sleep
 
 import click
@@ -23,7 +22,6 @@ from cwltool.load_tool import fetch_document
 from cwltool.main import printdeps
 
 from reana_client.cli.utils import add_access_token_options
-from reana_client.config import default_user
 from reana_client.utils import load_workflow_spec
 from reana_client.version import __version__
 


### PR DESCRIPTION
This PR removes legacy Python2 support (dropped in the upcoming `0.8.0` release) from the `cwl_runner.py` module.

In addition, unused imports have been cleaned up.