### PR TITLE
ci: added system dependencies for graphviz support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,11 @@ jobs:
             with:
                 python-version: 3.8
 
+          - name: Install system dependencies
+            run: |
+              sudo apt-get update -y
+              sudo apt-get install python3-dev graphviz libgraphviz-dev
+
           - name: Install Python dependencies
             run: |
                 pip install --upgrade pip setuptools py
@@ -106,6 +111,11 @@ jobs:
             with:
                 python-version: 3.8
 
+          - name: Install system dependencies
+            run: |
+              sudo apt-get update -y
+              sudo apt-get install python3-dev graphviz libgraphviz-dev
+
           - name: Install Python dependencies
             run: |
                 pip install --upgrade pip setuptools py
@@ -123,6 +133,11 @@ jobs:
           uses: actions/setup-python@v2
           with:
             python-version: 3.8
+
+        - name: Install system dependencies
+          run: |
+            sudo apt-get update -y
+            sudo apt-get install python3-dev graphviz libgraphviz-dev
 
         - name: Install Python dependencies
           run: |
@@ -168,6 +183,11 @@ jobs:
             uses: actions/setup-python@v2
             with:
               python-version: ${{ matrix.python }}
+
+          - name: Install system dependencies
+            run: |
+              sudo apt-get update -y
+              sudo apt-get install python3-dev graphviz libgraphviz-dev
 
           - name: Setup requirements builder
             run: |


### PR DESCRIPTION
Right now CI is not passing in multiple PRs, because of the `graphviz` issues. 
Please have a look into https://github.com/reanahub/reana-client/pull/550/checks?check_run_id=3518962084 for error log.
This PR will fix this issue by installing some system dependencies for `graphviz` support.