### PR TITLE
build: Require python >= 3.6 for install

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -14,6 +14,7 @@ The list of contributors in alphabetical order:
 - `Jan Okraska <https://orcid.org/0000-0002-1416-3244>`_
 - `Leticia Wanderley <https://orcid.org/0000-0003-4649-6630>`_
 - `Marco Vidal <https://orcid.org/0000-0002-9363-4971>`_
+- `Matthew Feickert <https://orcid.org/0000-0003-4124-7862>`_
 - `Rokas Maciulaitis <https://orcid.org/0000-0003-1064-6967>`_
 - `Sinclert Perez <https://www.linkedin.com/in/sinclert>`_
 - `Tibor Simko <https://orcid.org/0000-0001-7202-5803>`_

--- a/setup.py
+++ b/setup.py
@@ -72,6 +72,7 @@ setup(
             "reana-cwl-runner = reana_client.cli.cwl_runner:cwl_runner",
         ],
     },
+    python_requires=">=3.6",
     extras_require=extras_require,
     install_requires=install_requires,
     setup_requires=setup_requires,


### PR DESCRIPTION
Add `python_requires` of `>=3.6` to ensure that installs from PyPI coming from users on **Python 2** get the last release that still had Python 2 support and not a broken (for Python 2) release with Python 3 only syntax.