### PR TITLE
api: validate workflow name in create_workflow_from_json

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Version 0.8.1 (UNRELEASED)
 --------------------------
 
 - Adds support for Python 3.10.
+- Adds workflow name validation for ``create_workflow_from_json()`` Python API function.
 
 Version 0.8.0 (2021-11-24)
 --------------------------

--- a/reana_client/api/client.py
+++ b/reana_client/api/client.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2017, 2018, 2019, 2020, 2021 CERN.
+# Copyright (C) 2017, 2018, 2019, 2020, 2021, 2022 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -20,6 +20,7 @@ from bravado.exception import HTTPError
 from reana_client.config import ERROR_MESSAGES
 from reana_client.errors import FileDeletionError, FileUploadError
 from reana_client.utils import _validate_reana_yaml, is_uuid_v4
+from reana_commons.validation import validate_workflow_name
 from reana_commons.api_client import get_current_api_client
 from reana_commons.config import REANA_WORKFLOW_ENGINES
 from reana_commons.errors import REANASecretAlreadyExists, REANASecretDoesNotExist
@@ -225,6 +226,7 @@ def create_workflow_from_json(
             parameters={'files': ['file.txt'], 'parameters': {'key': 'value'}},
             workflow_engine='serial')
     """
+    validate_workflow_name(name)
     if is_uuid_v4(name):
         raise ValueError("Workflow name cannot be a valid UUIDv4")
     if not access_token:

--- a/reana_client/cli/utils.py
+++ b/reana_client/cli/utils.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2018, 2019, 2020, 2021 CERN.
+# Copyright (C) 2018, 2019, 2020, 2021, 2022 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -15,6 +15,7 @@ import sys
 from typing import Callable, NoReturn, Optional, Union
 
 import click
+from reana_commons.validation import validate_workflow_name
 
 from reana_client.config import (
     ERROR_MESSAGES,
@@ -237,19 +238,15 @@ def get_formatted_progress(progress):
     return "{0}/{1}".format(finished_jobs, total_jobs)
 
 
-def validate_workflow_name(ctx, _, workflow_name):
-    """Validate workflow name."""
-    not_allowed_characters = ["."]
-    if workflow_name:
-        for item in not_allowed_characters:
-            if item in workflow_name:
-                display_message(
-                    "Workflow name {} contains illegal "
-                    'character "{}"'.format(workflow_name, item),
-                    msg_type="error",
-                )
-                sys.exit(1)
-    return workflow_name
+def validate_workflow_name_parameter(
+    ctx: click.core.Context, _: click.core.Option, workflow_name: str
+) -> Union[str, NoReturn]:
+    """Validate workflow name parameter."""
+    try:
+        return validate_workflow_name(workflow_name)
+    except ValueError as e:
+        display_message(str(e), msg_type="error")
+        sys.exit(1)
 
 
 def key_value_to_dict(ctx, param, value):

--- a/reana_client/cli/workflow.py
+++ b/reana_client/cli/workflow.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2017, 2018, 2019, 2020, 2021 CERN.
+# Copyright (C) 2017, 2018, 2019, 2020, 2021, 2022 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -36,7 +36,7 @@ from reana_client.cli.utils import (
     parse_filter_parameters,
     parse_format_parameters,
     requires_environments,
-    validate_workflow_name,
+    validate_workflow_name_parameter,
 )
 from reana_client.config import ERROR_MESSAGES, RUN_STATUSES, TIMECHECK
 from reana_client.printer import display_message
@@ -294,7 +294,7 @@ def workflow_workflows(  # noqa: C901
     "-w",
     "--workflow",
     default="",
-    callback=validate_workflow_name,
+    callback=validate_workflow_name_parameter,
     help='Optional name of the workflow. [default is "workflow"]',
 )
 @click.option(
@@ -1027,7 +1027,7 @@ def workflow_stop(ctx, workflow, force_stop, access_token):  # noqa: D301
     "-w",
     "--workflow",
     default="",
-    callback=validate_workflow_name,
+    callback=validate_workflow_name_parameter,
     help='Optional name of the workflow. [default is "workflow"]',
 )
 @click.option(

--- a/reana_client/utils.py
+++ b/reana_client/utils.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2017, 2018, 2019, 2020, 2021 CERN.
+# Copyright (C) 2017, 2018, 2019, 2020, 2021, 2022 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -27,7 +27,7 @@ from reana_commons.serial import serial_load
 from reana_commons.snakemake import snakemake_load
 from reana_commons.yadage import yadage_load
 from reana_commons.utils import get_workflow_status_change_verb
-from reana_commons.workspaces import validate_workspace
+from reana_commons.validation import validate_workspace
 
 from reana_client.config import (
     reana_yaml_schema_file_path,
@@ -137,7 +137,7 @@ def load_reana_spec(
         reana_yaml["workflow"]["specification"] = load_workflow_spec(
             workflow_type,
             reana_yaml["workflow"].get("file"),
-            **_prepare_kwargs(reana_yaml)
+            **_prepare_kwargs(reana_yaml),
         )
 
         if (

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ install_requires = [
     "click>=7",
     "cwltool==3.1.20210628163208",
     "jsonpointer>=2.0",
-    "reana-commons[yadage,snakemake]>=0.8.0,<0.9.0",
+    "reana-commons[yadage,snakemake]>=0.8.2a2,<0.9.0",
     "tablib>=0.12.1,<0.13",
     "werkzeug>=0.14.1 ; python_version<'3.10'",
     "werkzeug>=0.15.0 ; python_version>='3.10'",

--- a/tests/test_cli_workflows.py
+++ b/tests/test_cli_workflows.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2018, 2019, 2020, 2021 CERN.
+# Copyright (C) 2018, 2019, 2020, 2021, 2022 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -482,7 +482,7 @@ def test_create_workflow_from_json(create_yaml_workflow_schema):
     response = {
         "message": "The workflow has been successfully created.",
         "workflow_id": "cdcf48b1-c2f3-4693-8230-b066e088c6ac",
-        "workflow_name": "mytest.1",
+        "workflow_name": "mytest",
     }
     env = {"REANA_SERVER_URL": "localhost"}
     reana_token = "000000"


### PR DESCRIPTION
closes https://github.com/reanahub/reana-client/issues/584

To test make sure it works:
- using `reana-client`:
```
$ reana-client create -w test.41
 ==> ERROR: Workflow name test.41 contains illegal character "."
 ```
 - [using Python API](https://blog.reana.io/posts/2021/reana-client-python-api/)