### PR TITLE
release: 0.8.1a2

### DIFF
--- a/reana_client/version.py
+++ b/reana_client/version.py
@@ -14,4 +14,4 @@ This file is imported by ``reana_client.__init__`` and parsed by
 
 from __future__ import absolute_import, print_function
 
-__version__ = "0.8.1a1"
+__version__ = "0.8.1a2"


### PR DESCRIPTION
[Demos' CI fails](https://github.com/reanahub/reana-demo-root6-roofit/actions/runs/1738526767) because we have some [breaking changes in a reana-commons import](https://github.com/reanahub/reana-client/commit/7f9dc7e262ecc6584275744d7e11f3651aacdaea#diff-4f20d18bf32c181d09b016a6a363171402d113bb01347de15da4768afcbe6998R30) that are not included in the reana-client release.

We need to release a new version so `reana-client validate` works again when is installed by [the GitHub Action](https://github.com/reanahub/reana-github-actions/blob/7e99bef6ad58bc352a54978156f6aa73bc08ebb3/local-validate/action.yml#L21).

