### PR TITLE
cli: fix `--follow` option

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Version 0.8.2 (UNRELEASED)
 --------------------------
 
 - Changes ``download`` command to add the possibility to write files to the standard output via ``-o -`` option.
+- Fixes ``start`` and ``run`` commands to correctly follow the execution of the workflow until termination.
 
 Version 0.8.1 (2022-02-15)
 --------------------------

--- a/reana_client/cli/workflow.py
+++ b/reana_client/cli/workflow.py
@@ -448,7 +448,7 @@ def workflow_start(
                 msg_type="success",
             )
             if follow:
-                while "running" in current_status:
+                while current_status in ["pending", "queued", "running"]:
                     time.sleep(TIMECHECK)
                     current_status = get_workflow_status(workflow, access_token).get(
                         "status"
@@ -457,7 +457,7 @@ def workflow_start(
                         get_workflow_status_change_msg(workflow, current_status),
                         msg_type="success",
                     )
-                    if "finished" in current_status:
+                    if current_status == "finished":
                         if follow:
                             display_message(
                                 "Listing workflow output files...", msg_type="info",
@@ -467,9 +467,10 @@ def workflow_start(
                                 workflow=workflow,
                                 access_token=access_token,
                                 output_format="url",
+                                human_readable_or_raw="raw",
                             )
                         sys.exit(0)
-                    elif "failed" in current_status or "stopped" in current_status:
+                    elif current_status in ["deleted", "failed", "stopped"]:
                         sys.exit(1)
         except Exception as e:
             logging.debug(traceback.format_exc())

--- a/tests/test_cli_workflows.py
+++ b/tests/test_cli_workflows.py
@@ -544,8 +544,15 @@ def test_workflow_start_successful(status):
 
 @pytest.mark.parametrize(
     "initial_status, final_status, exit_code",
-    [("running", "finished", 0), ("running", "failed", 1), ("running", "stopped", 1)],
+    [
+        ("running", "finished", 0),
+        ("running", "failed", 1),
+        ("running", "stopped", 1),
+        ("queued", "finished", 0),
+        ("pending", "deleted", 1),
+    ],
 )
+@patch("reana_client.cli.workflow.TIMECHECK", 0)
 def test_workflow_start_follow(initial_status, final_status, exit_code):
     """Test start workflow with follow flag."""
     workflow_name = "mytest.1"
@@ -606,6 +613,8 @@ def test_workflow_start_follow(initial_status, final_status, exit_code):
             assert result.exit_code == exit_code
             assert initial_expected_message in result.output
             assert final_Expected_message in result.output
+            if final_status == "finished":
+                assert "Listing workflow output files..." in result.output
 
 
 def test_workflows_validate(create_yaml_workflow_schema):


### PR DESCRIPTION
The `run` and `start` commands of reana-client have a `--follow` option to follow the execution of the workflow until termination.
However, the command stops as soon as the workflow is queued, without waiting for the end of the execution:
```console
$ reana-client run --follow
==> Creating a workflow...
==> Verifying REANA specification file...
  -> SUCCESS: Valid REANA specification file.
==> Verifying REANA specification parameters... 
  -> SUCCESS: REANA specification parameters appear valid.
==> Verifying workflow parameters and commands... 
  -> SUCCESS: Workflow parameters and commands appear valid.
==> Verifying dangerous workflow operations... 
  -> SUCCESS: Workflow operations appear valid.
==> Verifying compute backends in REANA specification file...
  -> SUCCESS: Workflow compute backends appear to be valid.
workflow.1
==> Uploading files...
==> SUCCESS: File /code/helloworld.py was successfully uploaded.
==> SUCCESS: File /data/names.txt was successfully uploaded.
==> Starting workflow...
==> SUCCESS: workflow.1 has been queued
```

How to test: execute `reana-client run --follow` on one of the demos, for example [reana-demo-helloworld](https://github.com/reanahub/reana-demo-helloworld/)

This is the expected result:
```console
$ reana-client run --follow
==> Creating a workflow...
==> Verifying REANA specification file...
  -> SUCCESS: Valid REANA specification file.
==> Verifying REANA specification parameters... 
  -> SUCCESS: REANA specification parameters appear valid.
==> Verifying workflow parameters and commands... 
  -> SUCCESS: Workflow parameters and commands appear valid.
==> Verifying dangerous workflow operations... 
  -> SUCCESS: Workflow operations appear valid.
==> Verifying compute backends in REANA specification file...
  -> SUCCESS: Workflow compute backends appear to be valid.
workflow.2
==> Uploading files...
==> SUCCESS: File /code/helloworld.py was successfully uploaded.
==> SUCCESS: File /data/names.txt was successfully uploaded.
==> Starting workflow...
==> SUCCESS: workflow.2 has been queued
==> SUCCESS: workflow.2 is pending
==> SUCCESS: workflow.2 is pending
==> SUCCESS: workflow.2 is running
==> SUCCESS: workflow.2 has been finished
==> Listing workflow output files...
https://localhost:30443/api/workflows/workflow.2/workspace/code/helloworld.py
https://localhost:30443/api/workflows/workflow.2/workspace/data/names.txt
https://localhost:30443/api/workflows/workflow.2/workspace/results/greetings.txt
```