### PR TITLE
validation: switch to docker registry v2 API for environments validation

### DIFF
--- a/reana_client/config.py
+++ b/reana_client/config.py
@@ -44,7 +44,7 @@ RUN_STATUSES = [
 ENVIRONMENT_IMAGE_SUSPECTED_TAGS_VALIDATOR = ["latest", "master", ""]
 """Warns user if above environment image tags are used."""
 
-DOCKER_REGISTRY_INDEX_URL = "https://index.docker.io/v1/repositories/{image}/tags/{tag}"
+DOCKER_REGISTRY_INDEX_URL = "https://hub.docker.com/v2/repositories/{image}/tags/{tag}"
 """Docker Hub registry index URL."""
 
 GITLAB_CERN_REGISTRY_INDEX_URL = (

--- a/reana_client/validation/environments.py
+++ b/reana_client/validation/environments.py
@@ -326,7 +326,7 @@ class EnvironmentValidatorBase:
 
         if not response.ok:
             if response.status_code == 404:
-                msg = response.text
+                msg = response.json().get("message")
                 self.messages.append(
                     {
                         "type": "warning",

--- a/reana_client/validation/environments.py
+++ b/reana_client/validation/environments.py
@@ -370,9 +370,7 @@ class EnvironmentValidatorBase:
         run_command("docker version", display=False, return_output=True)
         # Run ``id``` command inside the container.
         uid_gid_output = run_command(
-            'docker run -i -t --rm {} sh -c "/usr/bin/id -u && /usr/bin/id -G"'.format(
-                self._get_full_image_name(image, tag)
-            ),
+            f'docker run -i -t --rm --entrypoint /bin/sh {self._get_full_image_name(image, tag)} -c "/usr/bin/id -u && /usr/bin/id -G"',
             display=False,
             return_output=True,
         )


### PR DESCRIPTION
Docker registry v1 API is deprecated: https://www.docker.com/blog/registry-v1-api-deprecation/
and seems to be missing some of the data:

```
https://index.docker.io/v1/repositories/reanahub/reana-env-root6/tags/6.18.04 <-- works
https://index.docker.io/v1/repositories/reanahub/reana-env-aliphysics/tags/vAN-20180614-1 <-- does not work
```
Using the new registry v2 API both cases works fine:
```
https://hub.docker.com/v2/repositories/reanahub/reana-env-root6/tags/6.18.04
https://hub.docker.com/v2/repositories/reanahub/reana-env-aliphysics/tags/vAN-20180614-1
```

PR also fixes an issue found while trying to get docker image UID. Gist of the issue is here:
```
docker run -i -t --rm reanahub/reana-env-root6:6.18.04 sh -c "/usr/bin/id -u" --> 0
docker run -i -t --rm reanahub/reana-env-aliphysics:vAN-20180614-1 sh -c "/usr/bin/id -u" --> uid=0(root) gid=0(root) groups=0(root)
```
