### PR TITLE
files: respect gitignore when uploading files

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changes
 Version 0.9.0 (UNRELEASED)
 --------------------------
 
+- Adds support for ``.gitignore`` during file upload. Files that match ``.gitignore`` will not be uploaded.
 - Changes REANA specification loading and validation functionality by porting some of the logic to ``reana-commons``.
 - Fixes ``validate --environment`` command to detect illegal white space characters in image names.
 

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setup_requires = [
 
 install_requires = [
     "click>=7",
+    "pathspec==0.9.0",
     "jsonpointer>=2.0",
     "reana-commons[yadage,snakemake,cwl]>=0.9.0a7,<0.10.0",
     "tablib>=0.12.1,<0.13",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,7 @@
 from __future__ import absolute_import, print_function
 
 import pytest
+from typing import Dict
 
 
 @pytest.fixture()
@@ -51,6 +52,26 @@ def create_yaml_workflow_schema_with_workspace(create_yaml_workflow_schema: str)
           root_path: /var/reana
         """
     return reana_yaml_schema
+
+
+@pytest.fixture()
+def get_workflow_specification_with_directory() -> Dict:
+    """Return dummy workflow specification with "data" directory listed in inputs."""
+    reana_yaml_schema = {
+        "inputs": {
+            "directories": ["data"],
+        },
+        "version": "0.3.0",
+        "workflow": {
+            "specification": {
+                "steps": [
+                    {"commands": ["echo hello"], "environment": "python:2.7-slim"}
+                ]
+            },
+            "type": "serial",
+        },
+    }
+    return {"specification": reana_yaml_schema}
 
 
 @pytest.fixture()


### PR DESCRIPTION
Now `reana-client upload` command will respect `.gitignore` files.

Expected behavior:

- upload all `input.files`, ignore `.gitignore` in this case;

- upload all files or directories from `input.directories` that are not matched by `.gitignore`; 

- empty directories will not be uploaded

How to test:

1. Go to the `reana-demo-atlas-recast` example.

2. Create a `.gitignore` file there with the following content:

```
do-not-upload-*/
*.py[cod]
```

3. Go to the `workflow/` directory. Create files that will be ignored:

```bash
echo "Hello" > some_python.pyc
mkdir do-not-upload-me
echo "World" > do-not-upload-me/text.txt
```

4. Run example (with `run`), you can see that files that match `.gitignore` are not uploaded.

5. Check if reana-client works as before when `.gitignore` doesn't exist.

addresses #406