### PR TITLE
cli: add --show-deleted-runs option to list command

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -19,3 +19,4 @@ The list of contributors in alphabetical order:
 - `Rokas Maciulaitis <https://orcid.org/0000-0003-1064-6967>`_
 - `Sinclert Perez <https://www.linkedin.com/in/sinclert>`_
 - `Tibor Simko <https://orcid.org/0000-0001-7202-5803>`_
+- `Vladyslav Moisieienkov <https://orcid.org/0000-0001-9717-0775>`_

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ Version 0.9.0 (UNRELEASED)
 
 - Adds support for ``.reanaignore`` during file upload. Files that match ``.reanaignore`` will not be uploaded.
 - Adds support for ``.gitignore`` during file upload. Files that match ``.gitignore`` will not be uploaded.
+- Changes ``list`` to hide deleted workflows by default.
+- Changes ``list`` command to allow displaying deleted workflows via ``--all`` and ``--show-deleted-runs`` options.
 - Changes REANA specification loading and validation functionality by porting some of the logic to ``reana-commons``.
 - Fixes ``validate --environment`` command to detect illegal white space characters in image names.
 

--- a/reana_client/cli/utils.py
+++ b/reana_client/cli/utils.py
@@ -12,7 +12,7 @@ import json
 import os
 import shlex
 import sys
-from typing import Callable, NoReturn, Optional, Union
+from typing import Callable, NoReturn, Optional, List, Tuple, Union
 
 import click
 
@@ -165,7 +165,7 @@ def parse_format_parameters(_format):
         )
 
 
-def parse_filter_parameters(filters, filter_names):
+def parse_filter_parameters(filters, filter_names) -> Tuple[List[str], str]:
     """Return parsed filter parameters."""
     try:
         status_filters = []


### PR DESCRIPTION
Desired behavior for this PR:

```bash
$ reana-client list  # do not show deleted workflows, show all other statuses
$ reana-client list --show-deleted-runs  # shows deleted workflows and all other statuses
$ reana-client list --all  # shows deleted workflows and all other statuses

$ reana-client list --filter name=myworkflow  # show workflows that match the name, do not show deleted workflows if any
$ reana-client list --filter name=myworkflow  --show-deleted-runs  # show workflows that match the name, show deleted workflows if any

$ reana-client list --filter status=deleted  # show deleted workflows, no need to use  "--show-deleted-runs"
```

How to test:

- check that PR behaves in the desired way

closes #612