### PR TITLE
cli: add option to show workflow duration to `list` and `status` commands

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,7 @@ Version 0.9.0 (UNRELEASED)
 - Changes ``list`` to hide deleted workflows by default.
 - Changes ``list`` command to allow displaying deleted workflows via ``--all`` and ``--show-deleted-runs`` options.
 - Changes ``list`` command to allow displaying the duration of workflows with the ``--include-duration`` option.
+- Changes ``status`` command to allow displaying the duration of workflows with the ``--include-duration`` option.
 - Changes REANA specification loading and validation functionality by porting some of the logic to ``reana-commons``.
 - Fixes ``validate --environment`` command to detect illegal white space characters in image names.
 - Fixes ``list`` command to highlight the workflow specified in ``REANA_WORKON`` correctly.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,7 @@ Version 0.9.0 (UNRELEASED)
 - Adds support for ``.gitignore`` during file upload. Files that match ``.gitignore`` will not be uploaded.
 - Changes ``list`` to hide deleted workflows by default.
 - Changes ``list`` command to allow displaying deleted workflows via ``--all`` and ``--show-deleted-runs`` options.
+- Changes ``list`` command to allow displaying the duration of workflows with the ``--include-duration`` option.
 - Changes REANA specification loading and validation functionality by porting some of the logic to ``reana-commons``.
 - Fixes ``validate --environment`` command to detect illegal white space characters in image names.
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,7 @@ Version 0.9.0 (UNRELEASED)
 - Changes ``list`` command to allow displaying the duration of workflows with the ``--include-duration`` option.
 - Changes REANA specification loading and validation functionality by porting some of the logic to ``reana-commons``.
 - Fixes ``validate --environment`` command to detect illegal white space characters in image names.
+- Fixes ``list`` command to highlight the workflow specified in ``REANA_WORKON`` correctly.
 
 Version 0.8.2 (UNRELEASED)
 --------------------------

--- a/reana_client/cli/workflow.py
+++ b/reana_client/cli/workflow.py
@@ -41,6 +41,7 @@ from reana_client.config import ERROR_MESSAGES, RUN_STATUSES, TIMECHECK
 from reana_client.printer import display_message
 from reana_client.utils import (
     get_reana_yaml_file_path,
+    get_workflow_duration,
     get_workflow_name_and_run_number,
     get_workflow_status_change_msg,
     is_uuid_v4,
@@ -104,7 +105,8 @@ def workflow_execution_group(ctx):
     "-v",
     "--verbose",
     count=True,
-    help="Print out extra information: workflow id, user id, disk usage.",
+    help="Print out extra information: workflow id, user id, disk usage, "
+    "progress, duration.",
 )
 @human_readable_or_raw_option
 @click.option(
@@ -120,6 +122,14 @@ def workflow_execution_group(ctx):
     help="Filter workflow that contains certain filtering criteria. "
     "Use `--filter <columm_name>=<column_value>` pairs. "
     "Available filters are ``name`` and ``status``.",
+)
+@click.option(
+    "--include-duration",
+    "include_duration",
+    is_flag=True,
+    default=False,
+    help="Include the duration of the workflows in seconds. In case a workflow is in "
+    "progress, its duration as of now will be shown.",
 )
 @click.option(
     "--include-progress",
@@ -160,6 +170,7 @@ def workflows_list(  # noqa: C901
     page,
     size,
     filters,
+    include_duration: bool,
     include_progress,
     include_workspace_size,
     show_deleted_runs: bool,
@@ -215,6 +226,7 @@ def workflows_list(  # noqa: C901
         verbose_headers = ["id", "user"]
         workspace_size_header = ["size"]
         progress_header = ["progress"]
+        duration_header = ["duration"]
         headers = {
             "batch": ["name", "run_number", "created", "started", "ended", "status"],
             "interactive": [
@@ -232,12 +244,16 @@ def workflows_list(  # noqa: C901
             headers[type] += workspace_size_header
         if verbose or include_progress:
             headers[type] += progress_header
+        if verbose or include_duration:
+            headers[type] += duration_header
+
         data = []
         for workflow in response:
             workflow["size"] = workflow["size"][human_readable_or_raw]
             name, run_number = get_workflow_name_and_run_number(workflow["name"])
             workflow["name"] = name
             workflow["run_number"] = run_number
+            workflow["duration"] = get_workflow_duration(workflow)
             if type == "interactive":
                 workflow["session_uri"] = format_session_uri(
                     reana_server_url=ctx.obj.reana_server_url,
@@ -258,10 +274,22 @@ def workflows_list(  # noqa: C901
                     value = workflow.get(header)
                 row.append(value)
             data.append(row)
+
+        # Sort by given column, making sure that `None` is at the bottom of the list.
         sort_column_id = 2
         if sort_columm_name.lower() in headers[type]:
             sort_column_id = headers[type].index(sort_columm_name.lower())
-        data = sorted(data, key=lambda x: x[sort_column_id], reverse=True)
+        data = sorted(
+            data,
+            key=lambda x: (x[sort_column_id] is not None, x[sort_column_id]),
+            reverse=True,
+        )
+
+        # Substitute `None` with "-"
+        for row in data:
+            for i, value in enumerate(row):
+                row[i] = value or "-"
+
         workflow_ids = ["{0}.{1}".format(w[0], w[1]) for w in data]
         if os.getenv("REANA_WORKON", "") in workflow_ids:
             active_workflow_idx = workflow_ids.index(os.getenv("REANA_WORKON", ""))

--- a/reana_client/cli/workflow.py
+++ b/reana_client/cli/workflow.py
@@ -293,10 +293,7 @@ def workflows_list(  # noqa: C901
         workflow_ids = ["{0}.{1}".format(w[0], w[1]) for w in data]
         if os.getenv("REANA_WORKON", "") in workflow_ids:
             active_workflow_idx = workflow_ids.index(os.getenv("REANA_WORKON", ""))
-            for idx, row in enumerate(data):
-                if idx == active_workflow_idx:
-                    run_number = str(data[idx][headers[type].index("run_number")])
-                    run_number += " *"
+            data[active_workflow_idx][headers[type].index("run_number")] += " *"
         tablib_data = tablib.Dataset()
         tablib_data.headers = headers[type]
         for row in data:

--- a/tests/test_cli_workflows.py
+++ b/tests/test_cli_workflows.py
@@ -50,14 +50,14 @@ def test_workflows_server_ok():
         "items": [
             {
                 "status": "running",
-                "created": "2018-06-13T09:47:35.66097",
+                "created": "2018-06-13T09:47:35",
                 "user": "00000000-0000-0000-0000-000000000000",
                 "name": "mytest.1",
                 "id": "256b25f4-4cfb-4684-b7a8-73872ef455a1",
                 "size": {"raw": 0, "human_readable": "0 Bytes"},
                 "progress": {
-                    "run_started_at": "2018-06-13T09:47:40.28223",
-                    "run_finished_at": "2018-06-13T10:30:03.70303",
+                    "run_started_at": "2018-06-13T09:47:40",
+                    "run_finished_at": "2018-06-13T10:30:03",
                 },
             }
         ]
@@ -120,19 +120,19 @@ def test_workflows_sorting():
         "items": [
             {
                 "status": "running",
-                "created": "2018-06-13T09:47:35.66097",
+                "created": "2018-06-13T09:47:35",
                 "user": "00000000-0000-0000-0000-000000000000",
                 "name": "mytest.1",
                 "id": "256b25f4-4cfb-4684-b7a8-73872ef455a1",
                 "progress": {
-                    "run_started_at": "2018-06-13T09:47:40.28223",
-                    "run_finished_at": "2018-06-13T10:30:03.70303",
+                    "run_started_at": "2018-06-13T09:47:40",
+                    "run_finished_at": "2018-06-13T10:30:03",
                 },
                 "size": {"raw": 0, "human_readable": "0 Bytes"},
             },
             {
                 "status": "running",
-                "created": "2018-06-13T09:55:35.66097",
+                "created": "2018-06-13T09:55:35",
                 "user": "00000000-0000-0000-0000-000000000000",
                 "name": "mytest.2",
                 "id": "256b25f4-4cfb-4684-b7a8-73872ef455a2",
@@ -156,12 +156,8 @@ def test_workflows_sorting():
                 cli, ["list", "-t", reana_token, "--sort", "run_number"]
             )
             message = (
-                "mytest   2            2018-06-13T09:55:35.66097   -"
-                "                           -"
-                "                           running\n"
-                "mytest   1            2018-06-13T09:47:35.66097   "
-                "2018-06-13T09:47:40.28223   2018-06-13T10:30:03.70303"
-                "   running"
+                "mytest   2            2018-06-13T09:55:35   -                     -                     running\n"
+                "mytest   1            2018-06-13T09:47:35   2018-06-13T09:47:40   2018-06-13T10:30:03   running"
             )
             assert result.exit_code == 0
             assert message in result.output

--- a/tests/test_cli_workflows.py
+++ b/tests/test_cli_workflows.py
@@ -157,7 +157,7 @@ def test_workflows_sorting():
             )
             message = (
                 "mytest   2            2018-06-13T09:55:35   -                     -                     running\n"
-                "mytest   1            2018-06-13T09:47:35   2018-06-13T09:47:40   2018-06-13T10:30:03   running"
+                "mytest   1 *          2018-06-13T09:47:35   2018-06-13T09:47:40   2018-06-13T10:30:03   running"
             )
             assert result.exit_code == 0
             assert message in result.output

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of REANA.
+# Copyright (C) 2022 CERN.
+#
+# REANA is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""REANA client utils tests."""
+
+from unittest.mock import patch
+from datetime import datetime
+
+from reana_client.utils import get_workflow_duration
+
+
+def test_duration_pending_workflow():
+    workflow = {
+        "progress": {
+            "run_started_at": None,
+            "run_finished_at": None,
+        }
+    }
+    assert get_workflow_duration(workflow) is None
+
+
+def test_duration_finished_workflow():
+    workflow = {
+        "progress": {
+            "run_started_at": "2022-06-16T14:42:11",
+            "run_finished_at": "2022-06-16T14:43:22",
+        }
+    }
+    assert get_workflow_duration(workflow) == 60 + 11
+
+
+def test_duration_running_workflow():
+    workflow = {
+        "progress": {
+            "run_started_at": "2022-07-16T14:42:11",
+            "run_finished_at": None,
+        }
+    }
+    with patch("reana_client.utils.datetime") as mock_datetime:
+        mock_datetime.utcnow.return_value = datetime(2022, 7, 16, 14, 43, 22)
+        mock_datetime.strptime.side_effect = lambda *args, **kw: datetime.strptime(
+            *args, **kw
+        )
+        assert get_workflow_duration(workflow) == 60 + 11


### PR DESCRIPTION
Closes #616 

How to test:
1. Execute and create some workflows
2. Run `reana-client list --include-duration`
3. Run `reana-client list --include-duration --sort duration`
4. Run `reana-client status -w workflow --include-duration`

Expected result: the durations of the workflows are correctly displayed and the entries are sorted in the right order