### PR TITLE
workflow: show error when workflow fails after `start`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,7 +195,7 @@ jobs:
 
           - name: Install Python dependencies
             run: |
-              pip install -I -r .${{ matrix.testenv }}-requirements.txt
+              pip install -r .${{ matrix.testenv }}-requirements.txt
 
           - name: Run pytest
             run: ./run-tests.sh --check-pytest

--- a/tests/test_cli_workflows.py
+++ b/tests/test_cli_workflows.py
@@ -540,10 +540,19 @@ def test_create_workflow_from_json(create_yaml_workflow_schema):
 
 
 @pytest.mark.parametrize(
-    "status",
-    ["created", "running", "finished", "failed", "deleted", "stopped", "queued"],
+    "status, exit_code",
+    [
+        ("created", 0),
+        ("pending", 0),
+        ("queued", 0),
+        ("running", 0),
+        ("finished", 0),
+        ("failed", 1),
+        ("deleted", 1),
+        ("stopped", 1),
+    ],
 )
-def test_workflow_start_successful(status):
+def test_workflow_start_successful(status, exit_code):
     """Test workflow start when creation is successfull."""
     workflow_name = "mytest.1"
     response = {
@@ -569,7 +578,7 @@ def test_workflow_start_successful(status):
             result = runner.invoke(
                 cli, ["start", "-t", reana_token, "-w", response["workflow_name"]]
             )
-            assert result.exit_code == 0
+            assert result.exit_code == exit_code
             assert expected_message in result.output
 
 


### PR DESCRIPTION
Closes #629

How to test:

1. Create a new demo workflow: `reana-client create -w test`
2. Start the workflow without uploading inputs: `reana-client start -w test --follow`

Expected result: the workflow fails because of missing files and reana-client prints `==> ERROR: test has been failed`