### PR TITLE
cli: improve how reana spec is handled in `download` and `upload` commands

### DIFF
--- a/reana_client/cli/files.py
+++ b/reana_client/cli/files.py
@@ -250,10 +250,10 @@ def download_files(
             )
             sys.exit(1)
 
-        if "outputs" in reana_spec:
+        if reana_spec.get("outputs"):
             filenames = []
-            filenames += reana_spec["outputs"].get("files", [])
-            filenames += reana_spec["outputs"].get("directories", [])
+            filenames += reana_spec["outputs"].get("files") or []
+            filenames += reana_spec["outputs"].get("directories") or []
 
     if workflow:
         download_failed = False
@@ -347,9 +347,8 @@ def upload_files(  # noqa: C901
             )
             sys.exit(1)
 
-        if "inputs" in reana_spec:
+        if reana_spec.get("inputs"):
             filenames = []
-
             filenames += [
                 os.path.join(os.getcwd(), f)
                 for f in reana_spec["inputs"].get("files") or []


### PR DESCRIPTION
After introducing [missing workflow spec schema to get_workflow_specification endpoint](https://github.com/reanahub/reana-server/pull/549), reana-client started to include and set all the missing properties to `None` in the response of this endpoint. This affected `upload` and `download` commands since internally this endpoint is used to retrieve the spec and get the files to upload/download. This PR fixes this issue