### PR TITLE
codecov: add threshold values

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,20 +1,26 @@
 codecov:
-    require_ci_to_pass: yes
+  require_ci_to_pass: yes
 
 coverage:
-    precision: 2
-    round: down
-    range: "80...100"
+  status:
+    patch:
+      default:
+        informational: true
+    project:
+      default:
+        base: auto
+        target: auto
+        threshold: 2%
 
 parsers:
-    gcov:
-        branch_detection:
-            conditional: yes
-            loop: yes
-            method: no
-            macro: no
+  gcov:
+    branch_detection:
+      conditional: yes
+      loop: yes
+      method: no
+      macro: no
 
 comment:
-    layout: "reach,diff,flags,tree"
-    behavior: default
-    require_changes: no
+  layout: "reach,diff,flags,tree"
+  behavior: default
+  require_changes: no


### PR DESCRIPTION
Adds desired targets and threshold values for code coverage tests in pull requests.

Removes custom code coverage range to fall back to codecov defaults.