### PR TITLE
api: fix create_workflow_from_json to load workflow specification

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changes
 Version 0.9.2 (UNRELEASED)
 --------------------------
 
+- Fixes ``create_workflow_from_json`` API command to always send the workflow specification to the server.
 - Fixes ``list`` command to be case-insensitive when using the ``--sort`` flag to sort the workflow runs by a specific column name.
 
 Version 0.9.1 (2023-09-27)

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ install_requires = [
     "click>=7",
     "pathspec==0.9.0",
     "jsonpointer>=2.0",
-    "reana-commons[yadage,snakemake,cwl]>=0.9.3,<0.10.0",
+    "reana-commons[yadage,snakemake,cwl]>=0.9.4a1,<0.10.0",
     "tablib>=0.12.1,<0.13",
     "werkzeug>=0.14.1 ; python_version<'3.10'",
     "werkzeug>=0.15.0 ; python_version>='3.10'",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,8 @@
 
 from __future__ import absolute_import, print_function
 
+import textwrap
+
 import pytest
 from typing import Dict
 
@@ -117,6 +119,49 @@ def cwl_workflow_spec_step():
             out: [result]
         """
     return cwl_workflow_spec_step
+
+
+@pytest.fixture()
+def create_snakemake_yaml_external_input_workflow_schema():
+    """Return dummy schema for a Snakemake workflow with external parameters."""
+    reana_cwl_yaml_schema = """
+        inputs:
+          parameters:
+            input: config.yaml
+        workflow:
+          type: snakemake
+          file: Snakefile
+        outputs:
+          files:
+            - foo.txt
+        """
+    return reana_cwl_yaml_schema
+
+
+@pytest.fixture()
+def snakemake_workflow_spec_step_param():
+    """Return dummy Snakemake workflow loaded spec."""
+    snakefile = textwrap.dedent(
+        """
+        rule foo:
+            params:
+                param1=config["param1"],
+                param2=config["param2"],
+            output:
+                "foo.txt"
+    """
+    )
+    return snakefile
+
+
+@pytest.fixture()
+def external_parameter_yaml_file():
+    """Return dummy external parameter YAML file."""
+    config_yaml = """
+        param1: 200
+        param2: 300
+        """
+    return config_yaml
 
 
 @pytest.fixture()


### PR DESCRIPTION
Amend `create_workflow_from_json` so that the workflow specification is
always loaded in the REANA specification that is passed to reana-server.

Closes #666.
