### PR TITLE
cli: add include-command flag to list and status commands

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changes
 Version 0.9.2 (UNRELEASED)
 --------------------------
 
+- Changes ``status``, ``list`` commands to add the ``include-last-command`` flag to display the last command executed (or in execution) by the workflow.
 - Fixes ``create_workflow_from_json`` API command to always send the workflow specification to the server.
 - Fixes ``list`` command to be case-insensitive when using the ``--sort`` flag to sort the workflow runs by a specific column name.
 

--- a/reana_client/api/client.py
+++ b/reana_client/api/client.py
@@ -115,6 +115,7 @@ def get_workflows(
     search=None,
     include_progress=None,
     include_workspace_size=None,
+    include_last_command=None,
     workflow=None,
 ):
     """List all existing workflows.
@@ -130,6 +131,7 @@ def get_workflows(
     :param search: search workflows by name.
     :param include_progress: include progress information in the response.
     :param include_workspace_size: include workspace size information in the response.
+    :param include_last_command: include info about the command currently executing.
     :param workflow: name or id of the workflow.
 
     :return: a list of dictionaries with the information about the workflows.
@@ -148,6 +150,7 @@ def get_workflows(
             search=search,
             include_progress=include_progress,
             include_workspace_size=include_workspace_size,
+            include_last_command=include_last_command,
             workflow_id_or_name=workflow,
         ).result()
         if http_response.status_code == 200:
@@ -170,11 +173,12 @@ def get_workflows(
         raise e
 
 
-def get_workflow_status(workflow, access_token):
+def get_workflow_status(workflow, access_token, include_last_command=False):
     """Get status of previously created workflow.
 
     :param workflow: name or id of the workflow.
     :param access_token: access token of the current user.
+    :param include_last_command: show the last command executed/ing in the workflow.
 
     :return: a dictionary with the information about the workflow status.
              The dictionary has the following keys: ``id``, ``logs``, ``name``,
@@ -182,7 +186,9 @@ def get_workflow_status(workflow, access_token):
     """
     try:
         response, http_response = current_rs_api_client.api.get_workflow_status(
-            workflow_id_or_name=workflow, access_token=access_token
+            workflow_id_or_name=workflow,
+            access_token=access_token,
+            include_last_command=include_last_command,
         ).result()
         if http_response.status_code == 200:
             return response

--- a/reana_client/cli/utils.py
+++ b/reana_client/cli/utils.py
@@ -10,6 +10,7 @@
 import functools
 import json
 import os
+import re
 import shlex
 import sys
 from typing import Callable, NoReturn, Optional, List, Tuple, Union
@@ -275,6 +276,23 @@ def get_formatted_progress(progress):
     total_jobs = progress.get("total", {}).get("total") or "-"
     finished_jobs = progress.get("finished", {}).get("total") or "-"
     return "{0}/{1}".format(finished_jobs, total_jobs)
+
+
+def get_formatted_workflow_command(progress):
+    """Return lastly executed command if possible, otherwise try to return the step name."""
+    current_command = progress.get("current_command")
+    if current_command:
+        # Change multiline commands to a single line, replacing any sequence of consecutive newlines with a semicolon.
+        current_command = re.sub(r"\n+", "; ", current_command)
+        if current_command.startswith('bash -c "cd '):
+            current_command = current_command[current_command.index(";") + 2 : -2]
+        return current_command
+    else:
+        if "current_step_name" in progress and progress.get("current_step_name"):
+            current_step_name = progress.get("current_step_name")
+            return current_step_name
+        else:
+            return "-"
 
 
 def key_value_to_dict(ctx, param, value):

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ install_requires = [
     "click>=7",
     "pathspec==0.9.0",
     "jsonpointer>=2.0",
-    "reana-commons[yadage,snakemake,cwl]>=0.9.4a1,<0.10.0",
+    "reana-commons[yadage,snakemake,cwl]>=0.9.4a3,<0.10.0",
     "tablib>=0.12.1,<0.13",
     "werkzeug>=0.14.1 ; python_version<'3.10'",
     "werkzeug>=0.15.0 ; python_version>='3.10'",

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -11,6 +11,8 @@
 from unittest.mock import patch
 from datetime import datetime
 
+import pytest
+from reana_client.cli.utils import get_formatted_workflow_command
 from reana_client.utils import get_workflow_duration
 
 
@@ -47,3 +49,17 @@ def test_duration_running_workflow():
             *args, **kw
         )
         assert get_workflow_duration(workflow) == 60 + 11
+
+
+@pytest.mark.parametrize(
+    "progress,expected_output",
+    [
+        ({"current_command": 'bash -c "cd /some/path; some_command;"'}, "some_command"),
+        ({"current_command": "some_command"}, "some_command"),
+        ({"current_command": None, "current_step_name": "step_1"}, "step_1"),
+        ({"current_command": None, "current_step_name": None}, "-"),
+        ({}, "-"),
+    ],
+)
+def test_get_formatted_workflow_command(progress, expected_output):
+    assert get_formatted_workflow_command(progress) == expected_output


### PR DESCRIPTION
Add `--include-command` flag to the `list` and `status` commands that,
when set, will display info about the command currently being executed
by the workflow (or the last command). In case there is no info about
the command, the step name will be displayed, if possible.

Closes reanahub/reana-workflow-controller#486.
