### PR TITLE
cli: fix `run` command when specification does not contain `inputs`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Version 0.9.2 (UNRELEASED)
 
 - Fixes ``create_workflow_from_json`` API command to always send the workflow specification to the server.
 - Fixes ``list`` command to be case-insensitive when using the ``--sort`` flag to sort the workflow runs by a specific column name.
+- Fixes ``run`` wrapper command for workflows that do not contain ``inputs`` clause in their specification.
 
 Version 0.9.1 (2023-09-27)
 --------------------------

--- a/reana_client/cli/workflow.py
+++ b/reana_client/cli/workflow.py
@@ -1160,7 +1160,6 @@ def workflow_run(
     ctx.invoke(
         upload_files,
         workflow=ctx.workflow_name,
-        filenames=None,
         access_token=access_token,
     )
     display_message("Starting workflow...", msg_type="info")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2017, 2018, 2020, 2021, 2022 CERN.
+# Copyright (C) 2017, 2018, 2020, 2021, 2022, 2023 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -279,3 +279,16 @@ def cwl_workflow_spec_loaded():
         }
     }
     return cwl_workflow_spec
+
+
+@pytest.fixture()
+def spec_without_inputs():
+    """REANA specification without `inputs`."""
+    return {
+        "workflow": {
+            "type": "serial",
+            "steps": [
+                {"environment": "registry.example.org/foo/bar", "commands": ["sleep"]}
+            ],
+        }
+    }


### PR DESCRIPTION
Closes #689
