### PR TITLE
cli: implement list --shared argument

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -7,6 +7,7 @@ The list of contributors in alphabetical order:
 - [Audrius Mecionis](https://orcid.org/0000-0002-3759-1663)
 - [Camila Diaz](https://orcid.org/0000-0001-5543-797X)
 - [Clemens Lange](https://orcid.org/0000-0002-3632-3157)
+- [Daan Rosendal](https://orcid.org/0000-0002-3447-9000)
 - [Daniel Prelipcean](https://orcid.org/0000-0002-4855-194X)
 - [Diego Rodriguez](https://orcid.org/0000-0003-0649-2002)
 - [Dinos Kousidis](https://orcid.org/0000-0002-4914-4289)

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ COPY . /code
 RUN apt-get update -y && \
     apt-get install --no-install-recommends -y \
       gcc \
+      git \
       libpython3.12 \
       python3-pip \
       python3.12 \

--- a/docs/cmd_list.txt
+++ b/docs/cmd_list.txt
@@ -33,6 +33,7 @@ Workflow execution commands:
 Workflow sharing commands:
   share-add     Share a workflow with other users (read-only).
   share-remove  Unshare a workflow.
+  share-status  Show with whom a workflow is shared.
 
 Workspace interactive commands:
   close  Close an interactive session.

--- a/docs/cmd_list.txt
+++ b/docs/cmd_list.txt
@@ -30,6 +30,9 @@ Workflow execution commands:
   stop      Stop a running workflow.
   validate  Validate workflow specification file.
 
+Workflow sharing commands:
+  share-add  Share a workflow with other users (read-only).
+
 Workspace interactive commands:
   close  Close an interactive session.
   open   Open an interactive session inside the workspace.

--- a/docs/cmd_list.txt
+++ b/docs/cmd_list.txt
@@ -31,7 +31,8 @@ Workflow execution commands:
   validate  Validate workflow specification file.
 
 Workflow sharing commands:
-  share-add  Share a workflow with other users (read-only).
+  share-add     Share a workflow with other users (read-only).
+  share-remove  Unshare a workflow.
 
 Workspace interactive commands:
   close  Close an interactive session.

--- a/reana_client/api/client.py
+++ b/reana_client/api/client.py
@@ -1327,3 +1327,41 @@ def share_workflow(
             f"Message: {e.response.json()['message']}"
         )
         raise Exception(e.response.json()["message"])
+
+
+def unshare_workflow(workflow, user_email_to_unshare_with, access_token):
+    """Unshare a workflow with a user.
+
+    :param workflow: name or id of the workflow.
+    :param user_email_to_unshare_with: user to unshare the workflow with.
+    :param access_token: access token of the current user.
+
+    :return: a dictionary containing the ``workflow_id``, ``workflow_name``, and
+             a ``message`` key with the result of the operation.
+    """
+    try:
+        unshare_params = {
+            "workflow_id_or_name": workflow,
+            "user_email_to_unshare_with": user_email_to_unshare_with,
+            "access_token": access_token,
+        }
+
+        (response, http_response) = current_rs_api_client.api.unshare_workflow(
+            **unshare_params
+        ).result()
+
+        if http_response.status_code == 200:
+            return response
+        else:
+            raise Exception(
+                "Expected status code 200 but replied with "
+                f"{http_response.status_code}"
+            )
+
+    except HTTPError as e:
+        logging.debug(
+            "Workflow could not be unshared: "
+            f"\nStatus: {e.response.status_code}\nReason: {e.response.reason}\n"
+            f"Message: {e.response.json()['message']}"
+        )
+        raise Exception(e.response.json()["message"])

--- a/reana_client/api/client.py
+++ b/reana_client/api/client.py
@@ -1306,9 +1306,7 @@ def share_workflow(
     """
     try:
         share_params = {
-            "workflow_id_or_name": workflow,
             "user_email_to_share_with": user_email_to_share_with,
-            "access_token": access_token,
         }
 
         if message:
@@ -1318,7 +1316,9 @@ def share_workflow(
             share_params["valid_until"] = valid_until
 
         (response, http_response) = current_rs_api_client.api.share_workflow(
-            **share_params
+            workflow_id_or_name=workflow,
+            share_details=share_params,
+            access_token=access_token,
         ).result()
 
         if http_response.status_code == 200:

--- a/reana_client/api/client.py
+++ b/reana_client/api/client.py
@@ -115,6 +115,9 @@ def get_workflows(
     include_progress=None,
     include_workspace_size=None,
     workflow=None,
+    shared=None,
+    shared_by=None,
+    shared_with=None,
 ):
     """List all existing workflows.
 
@@ -130,6 +133,9 @@ def get_workflows(
     :param include_progress: include progress information in the response.
     :param include_workspace_size: include workspace size information in the response.
     :param workflow: name or id of the workflow.
+    :param shared: list all shared (owned and unowned) workflows.
+    :param shared_by: list workflows shared by the specified user(s).
+    :param shared_with: list workflows shared with the specified user(s).
 
     :return: a list of dictionaries with the information about the workflows.
              The information includes the workflow ``name``, ``id``, ``status``, ``size``,
@@ -148,6 +154,9 @@ def get_workflows(
             include_progress=include_progress,
             include_workspace_size=include_workspace_size,
             workflow_id_or_name=workflow,
+            shared=shared,
+            shared_by=shared_by,
+            shared_with=shared_with,
         ).result()
         if http_response.status_code == 200:
             return response.get("items")

--- a/reana_client/api/client.py
+++ b/reana_client/api/client.py
@@ -1365,3 +1365,38 @@ def unshare_workflow(workflow, user_email_to_unshare_with, access_token):
             f"Message: {e.response.json()['message']}"
         )
         raise Exception(e.response.json()["message"])
+
+
+def get_workflow_sharing_status(workflow, access_token):
+    """Get the share status of a workflow.
+
+    :param workflow: name or id of the workflow.
+    :param access_token: access token of the current user.
+
+    :return: a dictionary containing the ``workflow_id``, ``workflow_name``, and
+             a ``sharing_status`` key with the result of the operation.
+    """
+    try:
+        (
+            response,
+            http_response,
+        ) = current_rs_api_client.api.get_workflow_share_status(
+            workflow_id_or_name=workflow,
+            access_token=access_token,
+        ).result()
+
+        if http_response.status_code == 200:
+            return response
+        else:
+            raise Exception(
+                "Expected status code 200 but replied with "
+                f"{http_response.status_code}"
+            )
+
+    except HTTPError as e:
+        logging.debug(
+            "Workflow sharing status could not be retrieved: "
+            f"\nStatus: {e.response.status_code}\nReason: {e.response.reason}\n"
+            f"Message: {e.response.json()['message']}"
+        )
+        raise Exception(e.response.json()["message"])

--- a/reana_client/cli/__init__.py
+++ b/reana_client/cli/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2017, 2018, 2019, 2020, 2021, 2022 CERN.
+# Copyright (C) 2017, 2018, 2019, 2020, 2021, 2022, 2023 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -11,10 +11,9 @@ import os
 import sys
 
 import click
-from urllib3 import disable_warnings
-
-from reana_client.cli import workflow, files, ping, secrets, quotas, retention_rules
+from reana_client.cli import files, ping, quotas, retention_rules, secrets, workflow
 from reana_client.utils import get_api_url
+from urllib3 import disable_warnings
 
 DEBUG_LOG_FORMAT = (
     "[%(asctime)s] p%(process)s "
@@ -41,6 +40,7 @@ class ReanaCLI(click.Group):
         ping.configuration_group,
         workflow.workflow_management_group,
         workflow.workflow_execution_group,
+        workflow.workflow_sharing_group,
         workflow.interactive_group,
         files.files_group,
         retention_rules.retention_rules_group,

--- a/reana_client/cli/workflow.py
+++ b/reana_client/cli/workflow.py
@@ -1597,3 +1597,77 @@ def share_workflow_remove(ctx, workflow, access_token, users):  # noqa D412
 
     else:
         display_message(f"Cannot find workflow {workflow}", msg_type="error")
+
+
+@workflow_sharing_group.command("share-status")
+@check_connection
+@add_workflow_option
+@add_access_token_options
+@click.option(
+    "--format",
+    "_format",
+    multiple=True,
+    default=None,
+    help="Format output according to column titles or column "
+    "values. Use <columm_name>=<column_value> format.",
+)
+@click.option(
+    "--json",
+    "output_format",
+    flag_value="json",
+    default=None,
+    help="Get output in JSON format.",
+)
+@click.pass_context
+def share_workflow_status(
+    ctx, workflow, _format, output_format, access_token
+):  # noqa D412
+    """Show with whom a workflow is shared.
+
+    The `share-status` command allows for checking with whom a workflow is
+    shared.
+
+    Example:
+
+    $ reana-client share-status -w myanalysis.42
+    """
+    from reana_client.api.client import get_workflow_sharing_status
+
+    try:
+        sharing_status = get_workflow_sharing_status(workflow, access_token)
+
+        if sharing_status:
+            shared_with = sharing_status.get("shared_with", [])
+
+            if shared_with:
+                headers = ["user_email", "valid_until"]
+                data = [
+                    [
+                        entry["user_email"],
+                        (
+                            entry["valid_until"]
+                            if entry["valid_until"] is not None
+                            else "-"
+                        ),
+                    ]
+                    for entry in shared_with
+                ]
+
+                display_formatted_output(data, headers, _format, output_format)
+            else:
+                display_message(
+                    f"Workflow {workflow} is not shared with anyone.", msg_type="info"
+                )
+        else:
+            display_message(
+                f"Workflow {workflow} is not shared with anyone.", msg_type="info"
+            )
+    except Exception as e:
+        logging.debug(traceback.format_exc())
+        logging.debug(str(e))
+        display_message(
+            "An error occurred while checking workflow sharing status:\n{}".format(
+                str(e)
+            ),
+            msg_type="error",
+        )

--- a/reana_client/config.py
+++ b/reana_client/config.py
@@ -11,9 +11,6 @@
 reana_yaml_valid_file_names = ["reana.yaml", "reana.yml"]
 """REANA specification valid file names."""
 
-default_user = "00000000-0000-0000-0000-000000000000"
-"""Default user to use when submitting workflows to REANA Server."""
-
 ERROR_MESSAGES = {
     "missing_access_token": "Please provide your access token by using"
     " the -t/--access-token flag, or by setting the"

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,9 @@ extras_require = {
         "sphinx-click>=1.0.4",
     ],
     "tests": [
-        "pytest-reana>=0.95.0a2,<0.96.0",
+        "pytest-reana>=0.95.0a4,<0.96.0",
+        "reana-commons[kubernetes]>=0.95.0a3,<0.96.0",
+        "reana-commons[kubernetes] @ git+https://github.com/reanahub/reana-commons.git@master",
     ],
 }
 
@@ -40,7 +42,8 @@ install_requires = [
     "click>=7",
     "pathspec==0.9.0",
     "jsonpointer>=2.0",
-    "reana-commons[yadage,snakemake,cwl]>=0.95.0a2,<0.96.0",
+    "reana-commons[yadage,snakemake,cwl]>=0.95.0a3,<0.96.0",
+    "reana-commons[yadage,snakemake,cwl] @ git+https://github.com/reanahub/reana-commons.git@master",
     "tablib>=0.12.1,<0.13",
     "werkzeug>=0.14.1 ; python_version<'3.10'",
     "werkzeug>=0.15.0 ; python_version>='3.10'",

--- a/tests/test_cli_workflows.py
+++ b/tests/test_cli_workflows.py
@@ -487,6 +487,155 @@ def test_workflows_filter():
             assert "running" in json_response[0]["status"]
 
 
+def test_workflows_shared():
+    """Test workflow list command with --shared flag."""
+    response = {
+        "items": [
+            {
+                "status": "running",
+                "created": "2018-06-13T09:47:35.66097",
+                "user": "00000000-0000-0000-0000-000000000000",
+                "name": "mytest.1",
+                "id": "256b25f4-4cfb-4684-b7a8-73872ef455a1",
+                "size": {"raw": 0, "human_readable": "0 Bytes"},
+                "progress": {},
+            }
+        ]
+    }
+    status_code = 200
+    mock_http_response, mock_response = Mock(), Mock()
+    mock_http_response.status_code = status_code
+    mock_response = response
+    env = {"REANA_SERVER_URL": "localhost"}
+    reana_token = "000000"
+    runner = CliRunner(env=env)
+    with runner.isolation():
+        with patch(
+            "reana_client.api.client.current_rs_api_client",
+            make_mock_api_client("reana-server")(mock_response, mock_http_response),
+        ):
+            result = runner.invoke(cli, ["list", "--shared", "-t", reana_token])
+            assert result.exit_code == 0
+            assert "SHARED_WITH" in result.output
+            assert "SHARED_BY" in result.output
+
+
+def test_workflows_shared_with():
+    """Test workflow list command with --shared-with flag."""
+    response = {
+        "items": [
+            {
+                "status": "running",
+                "created": "2018-06-13T09:47:35.66097",
+                "user": "00000000-0000-0000-0000-000000000000",
+                "name": "mytest.1",
+                "id": "256b25f4-4cfb-4684-b7a8-73872ef455a1",
+                "size": {"raw": 0, "human_readable": "0 Bytes"},
+                "progress": {},
+            }
+        ]
+    }
+    status_code = 200
+    mock_http_response, mock_response = Mock(), Mock()
+    mock_http_response.status_code = status_code
+    mock_response = response
+    env = {"REANA_SERVER_URL": "localhost"}
+    reana_token = "000000"
+    runner = CliRunner(env=env)
+    with runner.isolation():
+        with patch(
+            "reana_client.api.client.current_rs_api_client",
+            make_mock_api_client("reana-server")(mock_response, mock_http_response),
+        ):
+            result = runner.invoke(
+                cli, ["list", "--shared-with", "anybody", "-t", reana_token]
+            )
+            assert result.exit_code == 0
+            assert "SHARED_WITH" in result.output
+            assert "SHARED_BY" not in result.output
+
+
+def test_workflows_shared_by():
+    """Test workflow list command with --shared-by flag."""
+    response = {
+        "items": [
+            {
+                "status": "running",
+                "created": "2018-06-13T09:47:35.66097",
+                "user": "00000000-0000-0000-0000-000000000000",
+                "name": "mytest.1",
+                "id": "256b25f4-4cfb-4684-b7a8-73872ef455a1",
+                "size": {"raw": 0, "human_readable": "0 Bytes"},
+                "progress": {},
+            }
+        ]
+    }
+    status_code = 200
+    mock_http_response, mock_response = Mock(), Mock()
+    mock_http_response.status_code = status_code
+    mock_response = response
+    env = {"REANA_SERVER_URL": "localhost"}
+    reana_token = "000000"
+    runner = CliRunner(env=env)
+    with runner.isolation():
+        with patch(
+            "reana_client.api.client.current_rs_api_client",
+            make_mock_api_client("reana-server")(mock_response, mock_http_response),
+        ):
+            result = runner.invoke(
+                cli, ["list", "--shared-by", "anybody", "-t", reana_token]
+            )
+            assert result.exit_code == 0
+            assert "SHARED_WITH" not in result.output
+            assert "SHARED_BY" in result.output
+
+
+def test_workflows_shared_with_and_shared_by():
+    """Test workflow list command with --shared-with and --shared-by flags."""
+    response = {
+        "items": [
+            {
+                "status": "running",
+                "created": "2018-06-13T09:47:35.66097",
+                "user": "00000000-0000-0000-0000-000000000000",
+                "name": "mytest.1",
+                "id": "256b25f4-4cfb-4684-b7a8-73872ef455a1",
+                "size": {"raw": 0, "human_readable": "0 Bytes"},
+                "progress": {},
+            }
+        ]
+    }
+    status_code = 200
+    mock_http_response, mock_response = Mock(), Mock()
+    mock_http_response.status_code = status_code
+    mock_response = response
+    env = {"REANA_SERVER_URL": "localhost"}
+    reana_token = "000000"
+    runner = CliRunner(env=env)
+    with runner.isolation():
+        with patch(
+            "reana_client.api.client.current_rs_api_client",
+            make_mock_api_client("reana-server")(mock_response, mock_http_response),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "list",
+                    "--shared-with",
+                    "anybody",
+                    "--shared-by",
+                    "anybody",
+                    "-t",
+                    reana_token,
+                ],
+            )
+            assert result.exit_code == 1
+            assert (
+                "Please provide either --shared-by or --shared-with, not both"
+                in result.output
+            )
+
+
 def test_workflow_create_failed():
     """Test workflow create when creation fails."""
     env = {"REANA_SERVER_URL": "localhost"}

--- a/tests/test_cli_workflows.py
+++ b/tests/test_cli_workflows.py
@@ -1049,3 +1049,38 @@ def test_share_add_workflow():
             )
             assert result.exit_code == 0
             assert response["message"] in result.output
+
+
+def test_share_remove_workflow():
+    """Test share-remove workflows."""
+    status_code = 200
+    response = {
+        "message": "is no longer shared with",
+        "workflow_id": "string",
+        "workflow_name": "string",
+    }
+    env = {"REANA_SERVER_URL": "localhost"}
+    mock_http_response, mock_response = Mock(), Mock()
+    mock_http_response.status_code = status_code
+    mock_response = response
+    reana_token = "000000"
+    runner = CliRunner(env=env)
+    with runner.isolation():
+        with patch(
+            "reana_client.api.client.current_rs_api_client",
+            make_mock_api_client("reana-server")(mock_response, mock_http_response),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "share-remove",
+                    "-t",
+                    reana_token,
+                    "--workflow",
+                    "test-workflow.1",
+                    "--user",
+                    "bob@.cern.ch",
+                ],
+            )
+            assert result.exit_code == 0
+            assert response["message"] in result.output

--- a/tests/test_cli_workflows.py
+++ b/tests/test_cli_workflows.py
@@ -1084,3 +1084,36 @@ def test_share_remove_workflow():
             )
             assert result.exit_code == 0
             assert response["message"] in result.output
+
+
+def test_share_status_workflow():
+    """Test share-status workflows."""
+    status_code = 200
+    response = {
+        "message": "is not shared with anyone",
+        "workflow_id": "string",
+        "workflow_name": "string",
+    }
+    env = {"REANA_SERVER_URL": "localhost"}
+    mock_http_response, mock_response = Mock(), Mock()
+    mock_http_response.status_code = status_code
+    mock_response = response
+    reana_token = "000000"
+    runner = CliRunner(env=env)
+    with runner.isolation():
+        with patch(
+            "reana_client.api.client.current_rs_api_client",
+            make_mock_api_client("reana-server")(mock_response, mock_http_response),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "share-status",
+                    "-t",
+                    reana_token,
+                    "--workflow",
+                    "test-workflow.1",
+                ],
+            )
+            assert result.exit_code == 0
+            assert response["message"] in result.output


### PR DESCRIPTION
Adds new `--shared`, `--shared-by`, and `--shared-with` arguments to the
`list` CLI command to display workflows along with their sharing
information.

Closes #687
