### PR TITLE
validation: improve warning message for unexpected properties

### DIFF
--- a/reana_client/validation/utils.py
+++ b/reana_client/validation/utils.py
@@ -58,15 +58,26 @@ def validate_reana_spec(
                 msg_type="warning",
                 indented=True,
             )
-        for warning_key, warning_value in validation_warnings.items():
+        for warning_key, warning_values in validation_warnings.items():
             if warning_key == "additional_properties":
                 # warning_values is a list of unexpected properties
+                messages = [
+                    f"'{value['property']}'"
+                    + (f" (at {value['path']})" if value["path"] else "")
+                    for value in warning_values
+                ]
                 message = (
                     f"Unexpected properties found in REANA specification file: "
-                    f"{', '.join(warning_value)}"
+                    f"{', '.join(messages)}."
                 )
             else:
-                message = warning_value
+                # warning_values is a list of dictionaries with 'message' and 'path'
+                messages = [
+                    f"{value['message']}"
+                    + (f" (at {value['path']})" if value["path"] else "")
+                    for value in warning_values
+                ]
+                message = f"{'; '.join(messages)}."
             display_message(
                 message,
                 msg_type="warning",

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ install_requires = [
     "click>=7",
     "pathspec==0.9.0",
     "jsonpointer>=2.0",
-    "reana-commons[yadage,snakemake,cwl]>=0.9.4a1,<0.10.0",
+    "reana-commons[yadage,snakemake,cwl]>=0.9.4a3,<0.10.0",
     "tablib>=0.12.1,<0.13",
     "werkzeug>=0.14.1 ; python_version<'3.10'",
     "werkzeug>=0.15.0 ; python_version>='3.10'",


### PR DESCRIPTION
Change the warning message generated when unexpected properties are
found in the REANA specification during the validation phase to include
the path to the invalidating properties.

Closes #679.
