### PR TITLE
test(snakemake): allow running Snakemake 7 tests on Python 3.11+ (#700)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ install_requires = [
     "click>=7",
     "pathspec==0.9.0",
     "jsonpointer>=2.0",
-    "reana-commons[yadage,snakemake,cwl]>=0.9.5,<0.10.0",
+    "reana-commons[yadage,snakemake,cwl]>=0.9.6,<0.10.0",
     "tablib>=0.12.1,<0.13",
     "werkzeug>=0.14.1 ; python_version<'3.10'",
     "werkzeug>=0.15.0 ; python_version>='3.10'",

--- a/tests/test_cli_workflows.py
+++ b/tests/test_cli_workflows.py
@@ -580,10 +580,6 @@ def test_create_snakemake_workflow_from_json_parameters(
     external_parameter_yaml_file,
 ):
     """Test create workflow from json with external parameters."""
-    if sys.version_info.major == 3 and sys.version_info.minor in (11, 12):
-        pytest.xfail(
-            "Snakemake features of reana-client are not supported on Python 3.11"
-        )
     status_code = 201
     response = {
         "message": "The workflow has been successfully created.",


### PR DESCRIPTION
After upgrading Snakemake to version 7.32.4 (reanahub/reana-commons#435)
there is no need to avoid running Snakemake tests on Python 3.11 and
3.12, as it should be supported.

Closes #655
