### PR TITLE
build(docker): create `reana-client` container image

### DIFF
--- a/.commitlintrc.yaml
+++ b/.commitlintrc.yaml
@@ -1,6 +1,6 @@
 rules:
   body-case: [2, always, sentence-case]
-  body-full-stop: [2, always]
+  body-full-stop: [1, always]
   body-leading-blank: [2, always]
   body-max-line-length: [2, always, 72]
   footer-leading-blank: [2, always]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,26 @@ jobs:
       - name: Check Python manifest completeness
         run: ./run-tests.sh --check-manifest
 
+  lint-dockerfile:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Check Dockerfile compliance
+        run: ./run-tests.sh --check-dockerfile
+
+  docker-build:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Build Docker image
+        run: |
+          ./run-tests.sh --check-docker-build
+          ./run-tests.sh --check-docker-run
+
   docs-cli-commands:
     runs-on: ubuntu-20.04
     steps:
@@ -203,3 +223,33 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml
+
+  release-docker:
+    runs-on: ubuntu-20.04
+    if: >
+      vars.RELEASE_DOCKER == 'true' &&
+      github.event_name == 'push' &&
+      startsWith(github.ref, 'refs/tags/')
+    needs:
+      - docs-cli-api
+      - docs-cli-commands
+      - docs-sphinx
+      - lint-black
+      - lint-check-manifest
+      - lint-commitlint
+      - lint-dockerfile
+      - lint-flake8
+      - lint-pydocstyle
+      - lint-shellcheck
+      - python-tests
+    steps:
+      - name: Release Docker image
+        uses: reanahub/reana-github-actions/release-docker@v1
+        with:
+          username: ${{ secrets.DOCKER_USER }}
+          token: ${{ secrets.DOCKER_TOKEN }}
+          organisation: ${{ vars.DOCKER_ORGANISATION }}
+          registry: ${{ vars.DOCKER_REGISTRY }}
+          platform: |
+            linux/amd64
+            linux/arm64

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # This file is part of REANA.
-# Copyright (C) 2017, 2018, 2020, 2021 CERN.
+# Copyright (C) 2017, 2018, 2020, 2021, 2024 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,63 @@
+# This file is part of REANA.
+# Copyright (C) 2024 CERN.
+#
+# REANA is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+# Use Ubuntu LTS base image
+FROM docker.io/library/ubuntu:20.04
+
+# Use default answers in installation commands
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Use distutils provided by the standard Python library instead of the vendored one in
+# setuptools, so that editable installations are stored in the right directory.
+# See https://github.com/pypa/setuptools/issues/3301
+ENV SETUPTOOLS_USE_DISTUTILS=stdlib
+
+# Add sources to `/code` and work there
+WORKDIR /code
+COPY . /code
+
+# Install system dependencies and reana-client in one go
+# hadolint ignore=DL3008,DL3013
+RUN apt-get update -y && \
+    apt-get install --no-install-recommends -y \
+      gcc \
+      libpython3.8 \
+      python3-pip \
+      python3.8 \
+      python3.8-dev && \
+    # `pip3 install kubernetes` needed due to an old version of system pip3
+    pip3 install --no-cache-dir kubernetes '.[tests]' && \
+    apt-get remove -y \
+      gcc \
+      python3.8-dev && \
+    apt-get autoremove -y && \
+    apt-get clean && \
+    rm -rf /code /var/lib/apt/lists/*
+
+# Run container as `reana` user with UID `1000`, which should match
+# current host user in most situations
+# hadolint ignore=DL3059
+RUN adduser --uid 1000  reana --gid 0 && \
+    chown -R reana:root /home/reana
+WORKDIR /home/reana
+
+# Run reana-client upon entry
+USER reana
+ENTRYPOINT ["reana-client"]
+
+# Set image labels
+LABEL org.opencontainers.image.authors="team@reanahub.io"
+LABEL org.opencontainers.image.created="2024-03-14"
+LABEL org.opencontainers.image.description="REANA reproducible analysis platform - command-line client"
+LABEL org.opencontainers.image.documentation="https://reana-client.readthedocs.io/"
+LABEL org.opencontainers.image.licenses="MIT"
+LABEL org.opencontainers.image.source="https://github.com/reanahub/reana-client"
+LABEL org.opencontainers.image.title="reana-client"
+LABEL org.opencontainers.image.url="https://github.com/reanahub/reana-client"
+LABEL org.opencontainers.image.vendor="reanahub"
+# x-release-please-start-version
+LABEL org.opencontainers.image.version="0.9.3"
+# x-release-please-end

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -11,6 +11,7 @@ include *.txt
 include *.yaml
 include *.yml
 include .flake8
+include Dockerfile
 include LICENSE
 include pytest.ini
 include tox.ini

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -64,6 +64,18 @@ check_cli_api () {
     rm cli_api.md
 }
 
+check_dockerfile () {
+    docker run -i --rm docker.io/hadolint/hadolint:v2.12.0 < Dockerfile
+}
+
+check_docker_build () {
+    docker build -t docker.io/reanahub/reana-client .
+}
+
+check_docker_run () {
+    docker run --rm -v "$PWD"/tests:/home/reana/tests --entrypoint /bin/bash docker.io/reanahub/reana-client -c 'pytest tests'
+}
+
 check_sphinx () {
     sphinx-build -qnNW docs docs/_build/html
     sphinx-build -qnNW -b doctest docs docs/_build/doctest
@@ -82,6 +94,9 @@ check_all() {
     check_manifest
     check_cli_cmds
     check_cli_api
+    check_dockerfile
+    check_docker_build
+    check_docker_run
     check_sphinx
     check_pytest
 }
@@ -101,6 +116,9 @@ case $arg in
     --check-manifest) check_manifest;;
     --check-cli-cmds) check_cli_cmds;;
     --check-cli-api) check_cli_api;;
+    --check-dockerfile) check_dockerfile;;
+    --check-docker-build) check_docker_build;;
+    --check-docker-run) check_docker_run;;
     --check-sphinx) check_sphinx;;
     --check-pytest) check_pytest;;
     *) echo "[ERROR] Invalid argument '$arg'. Exiting." && exit 1;;


### PR DESCRIPTION
Usage example:

```console
$ cd reana-demo-root6-roofit
$ export REANA_SERVER_URL=https://reana.cern.ch
$ export REANA_ACCESS_TOKEN=xxxxxxxxxxxxxxxxxxx
$ docker pull docker.io/reanahub/reana-client:0.9.3
$ docker run -i -t --rm -v $PWD:/home/reana \
    --env REANA_SERVER_URL --env REANA_ACCESS_TOKEN \
    docker.io/reanahub/reana-client:0.9.3 run -w test
```

Closes #709