### PR TITLE
build(python): drop support for Python 3.6 and 3.7 (#715)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.8'
+          python-version: "3.8"
 
       - name: Install Python dependencies
         run: pip install black
@@ -70,7 +70,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.8'
+          python-version: "3.8"
 
       - name: Check compliance with pep8, pyflakes and circular complexity
         run: |
@@ -86,7 +86,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.8'
+          python-version: "3.8"
 
       - name: Install Python dependencies
         run: pip install pydocstyle
@@ -102,7 +102,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.8'
+          python-version: "3.8"
 
       - name: Install Python dependencies
         run: pip install check-manifest
@@ -138,7 +138,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.8'
+          python-version: "3.8"
 
       - name: Install Python dependencies
         run: |
@@ -156,7 +156,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.8'
+          python-version: "3.8"
 
       - name: Install Python dependencies
         run: |
@@ -174,7 +174,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.8'
+          python-version: "3.8"
 
       - name: Install Python dependencies
         run: |
@@ -189,14 +189,14 @@ jobs:
     strategy:
       matrix:
         testenv: [lowest, release]
-        python: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python ${{ matrix.python }}
+      - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python }}
+          python-version: ${{ matrix.python-version }}
 
       - name: Setup requirements builder
         run: |
@@ -218,7 +218,7 @@ jobs:
         run: ./run-tests.sh --check-pytest
 
       - name: Codecov Coverage
-        if: matrix.python == '3.8'
+        if: matrix.python-version == '3.8'
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/reana_client/utils.py
+++ b/reana_client/utils.py
@@ -139,10 +139,6 @@ def get_workflow_duration(workflow: Dict) -> Optional[int]:
         time is not present.
     """
 
-    # FIXME: Use datetime.fromisoformat when moving to Python 3.7 or higher
-    def fromisoformat(date_string):
-        return datetime.strptime(date_string, "%Y-%m-%dT%H:%M:%S")
-
     progress = workflow.get("progress", {})
     run_started_at = progress.get("run_started_at")
     run_finished_at = progress.get("run_finished_at")
@@ -150,11 +146,11 @@ def get_workflow_duration(workflow: Dict) -> Optional[int]:
 
     duration = None
     if run_started_at:
-        start_time = fromisoformat(run_started_at)
+        start_time = datetime.fromisoformat(run_started_at)
         if run_finished_at:
-            end_time = fromisoformat(run_finished_at)
+            end_time = datetime.fromisoformat(run_finished_at)
         elif run_stopped_at:
-            end_time = fromisoformat(run_stopped_at)
+            end_time = datetime.fromisoformat(run_stopped_at)
         else:
             end_time = datetime.utcnow()
         duration = round((end_time - start_time).total_seconds())

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,6 @@ install_requires = [
     "tablib>=0.12.1,<0.13",
     "werkzeug>=0.14.1 ; python_version<'3.10'",
     "werkzeug>=0.15.0 ; python_version>='3.10'",
-    "swagger_spec_validator>=2.4.0,<3.0.0; python_version<'3.7'",
 ]
 
 packages = find_packages()
@@ -82,7 +81,7 @@ setup(
             "reana-cwl-runner = reana_client.cli.cwl_runner:cwl_runner",
         ],
     },
-    python_requires=">=3.6",
+    python_requires=">=3.8",
     extras_require=extras_require,
     install_requires=install_requires,
     setup_requires=setup_requires,
@@ -94,8 +93,6 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,14 +1,14 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2022 CERN.
+# Copyright (C) 2022, 2024 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
 """REANA client utils tests."""
 
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 from datetime import datetime
 
 from reana_client.utils import get_workflow_duration
@@ -52,9 +52,7 @@ def test_duration_running_workflow():
             "run_finished_at": None,
         }
     }
-    with patch("reana_client.utils.datetime") as mock_datetime:
-        mock_datetime.utcnow.return_value = datetime(2022, 7, 16, 14, 43, 22)
-        mock_datetime.strptime.side_effect = lambda *args, **kw: datetime.strptime(
-            *args, **kw
-        )
+    mock_datetime = Mock(wraps=datetime)
+    mock_datetime.utcnow.return_value = datetime(2022, 7, 16, 14, 43, 22)
+    with patch("reana_client.utils.datetime", mock_datetime):
         assert get_workflow_duration(workflow) == 60 + 11


### PR DESCRIPTION
BREAKING CHANGE: drop support for Python 3.6 and 3.7

Closes reanahub/reana#784
