### PR TITLE
docs(cli): fix `open` command documentation typo (#716)

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -6,6 +6,7 @@ The list of contributors in alphabetical order:
 - [Anton Khodak](https://orcid.org/0000-0003-3263-4553)
 - [Audrius Mecionis](https://orcid.org/0000-0002-3759-1663)
 - [Camila Diaz](https://orcid.org/0000-0001-5543-797X)
+- [Clemens Lange](https://orcid.org/0000-0002-3632-3157)
 - [Daniel Prelipcean](https://orcid.org/0000-0002-4855-194X)
 - [Diego Rodriguez](https://orcid.org/0000-0003-0649-2002)
 - [Dinos Kousidis](https://orcid.org/0000-0002-4914-4289)

--- a/reana_client/cli/workflow.py
+++ b/reana_client/cli/workflow.py
@@ -1366,7 +1366,7 @@ def workflow_open_interactive_session(
 
     The ``open`` command allows to open interactive session processes on top of
     the workflow workspace, such as Jupyter notebooks. This is useful to
-    quickly inspect and analyse the produced files while the workflow is stlil
+    quickly inspect and analyse the produced files while the workflow is still
     running.
 
     Examples:\n


### PR DESCRIPTION
Fix typo that I spotted during the demo this morning.