### PR TITLE
deprecations setuptools

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,6 +213,7 @@ jobs:
       - name: Install Python dependencies
         run: |
           pip install -r .${{ matrix.testenv }}-requirements.txt
+          pip install -e .[tests]
 
       - name: Run pytest
         run: ./run-tests.sh --check-pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,9 @@
+# This file is part of REANA.
+# Copyright (C) 2024 CERN.
+#
+# REANA is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -82,7 +82,7 @@ check_sphinx () {
 }
 
 check_pytest () {
-    python setup.py test
+    pytest
 }
 
 check_all() {

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,9 +4,6 @@
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
-[aliases]
-test = pytest
-
 [build_sphinx]
 source-dir = docs/
 build-dir = docs/_build

--- a/setup.py
+++ b/setup.py
@@ -38,10 +38,6 @@ for key, reqs in extras_require.items():
         continue
     extras_require["all"].extend(reqs)
 
-setup_requires = [
-    "pytest-runner>=2.7",
-]
-
 install_requires = [
     "click>=7",
     "pathspec==0.9.0",
@@ -84,7 +80,6 @@ setup(
     python_requires=">=3.8",
     extras_require=extras_require,
     install_requires=install_requires,
-    setup_requires=setup_requires,
     tests_require=tests_require,
     classifiers=[
         "Development Status :: 3 - Alpha",

--- a/setup.py
+++ b/setup.py
@@ -18,10 +18,6 @@ from setuptools import find_packages, setup
 readme = open("README.md").read()
 history = open("CHANGELOG.md").read()
 
-tests_require = [
-    "pytest-reana>=0.95.0a2,<0.96.0",
-]
-
 extras_require = {
     "docs": [
         "myst-parser",
@@ -29,7 +25,9 @@ extras_require = {
         "sphinx-rtd-theme>=0.1.9",
         "sphinx-click>=1.0.4",
     ],
-    "tests": tests_require,
+    "tests": [
+        "pytest-reana>=0.95.0a2,<0.96.0",
+    ],
 }
 
 extras_require["all"] = []
@@ -80,7 +78,6 @@ setup(
     python_requires=">=3.8",
     extras_require=extras_require,
     install_requires=install_requires,
-    tests_require=tests_require,
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Environment :: Console",

--- a/tox.ini
+++ b/tox.ini
@@ -5,9 +5,9 @@
 # under the terms of the MIT License; see LICENSE file for more details.
 
 [tox]
-envlist = py36, py37, py38, py39, py310, py311, py312
+envlist = py38, py39, py310, py311, py312
 
 [testenv]
 deps = pytest
        pytest-cov
-commands = {envpython} setup.py test
+commands = pytest {posargs}


### PR DESCRIPTION
- **ci(pytest): invoke `pytest` directly instead of `setup.py test` (#725)**
- **build(python): remove deprecated `pytest-runner` (#725)**
- **build(python): use optional deps instead of `tests_require` (#725)**
- **build(python): add minimal `pyproject.toml` (#725)**

Closes https://github.com/reanahub/reana/issues/814
