### PR TITLE
ci(actions): pin setuptools 70

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,7 +142,7 @@ jobs:
 
       - name: Install Python dependencies
         run: |
-          pip install --upgrade pip setuptools py
+          pip install --upgrade pip 'setuptools<71' py
           pip install -e .[all]
 
       - name: Verify reana client commands list
@@ -160,7 +160,7 @@ jobs:
 
       - name: Install Python dependencies
         run: |
-          pip install --upgrade pip setuptools py
+          pip install --upgrade pip 'setuptools<71' py
           pip install -e .[all]
 
       - name: Verify reana client api docs
@@ -178,7 +178,7 @@ jobs:
 
       - name: Install Python dependencies
         run: |
-          pip install --upgrade pip setuptools py
+          pip install --upgrade pip 'setuptools<71' py
           pip install -e .[all]
 
       - name: Run Sphinx documentation with doctests
@@ -200,7 +200,7 @@ jobs:
 
       - name: Setup requirements builder
         run: |
-          pip install --upgrade pip setuptools py
+          pip install --upgrade pip 'setuptools<71' py
           pip install wheel
           pip install requirements-builder
           if [[ ${{ matrix.testenv }} == lowest ]]; then

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -6,6 +6,7 @@ The list of contributors in alphabetical order:
 - [Anton Khodak](https://orcid.org/0000-0003-3263-4553)
 - [Audrius Mecionis](https://orcid.org/0000-0002-3759-1663)
 - [Camila Diaz](https://orcid.org/0000-0001-5543-797X)
+- [Clemens Lange](https://orcid.org/0000-0002-3632-3157)
 - [Daniel Prelipcean](https://orcid.org/0000-0002-4855-194X)
 - [Diego Rodriguez](https://orcid.org/0000-0003-0649-2002)
 - [Dinos Kousidis](https://orcid.org/0000-0002-4914-4289)

--- a/reana_client/cli/workflow.py
+++ b/reana_client/cli/workflow.py
@@ -1366,7 +1366,7 @@ def workflow_open_interactive_session(
 
     The ``open`` command allows to open interactive session processes on top of
     the workflow workspace, such as Jupyter notebooks. This is useful to
-    quickly inspect and analyse the produced files while the workflow is stlil
+    quickly inspect and analyse the produced files while the workflow is still
     running.
 
     Examples:\n


### PR DESCRIPTION
Pin `setuptools` to the maximum version of 70 to allow working on Ubuntu 20.04 LTS based environments. (New versions of `setuptools` are not compatible.)

Note that this fix is necessary only for the `maint-0.9` branches and the REANA 0.9 release series. In `master` we have switched to Ubuntu 24.04 LTS based environments and Python 3.12 and no pinning is necessary there.