### PR TITLE
feat(cli): add --follow flag to logs command (#729)

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -15,6 +15,7 @@ The list of contributors in alphabetical order:
 - [Giuseppe Steduto](https://orcid.org/0009-0002-1258-8553)
 - [Harri Hirvonsalo](https://orcid.org/0000-0002-5503-510X)
 - [Jan Okraska](https://orcid.org/0000-0002-1416-3244)
+- [Jelizaveta Lemeševa](https://orcid.org/0009-0003-6606-9270)
 - [Leticia Wanderley](https://orcid.org/0000-0003-4649-6630)
 - [Marco Donadoni](https://orcid.org/0000-0003-2922-5505)
 - [Marco Vidal](https://orcid.org/0000-0002-9363-4971)

--- a/reana_client/config.py
+++ b/reana_client/config.py
@@ -77,3 +77,9 @@ JOB_STATUS_TO_MSG_COLOR = {
 
 STD_OUTPUT_CHAR = "-"
 """Character used to refer to the standard output."""
+
+CLI_LOGS_FOLLOW_MIN_INTERVAL = 1
+"""Minimum interval between log requests in seconds."""
+
+CLI_LOGS_FOLLOW_DEFAULT_INTERVAL = 10
+"""Default interval between log requests in seconds."""


### PR DESCRIPTION
Closes https://github.com/reanahub/reana-client/issues/730

Old code is moved to `retrieve_workflow_logs` function, log following implemented in `follow_workflow_logs`.

Added test for the command (both retrieval and following).