### PR TITLE
feat(validation): add workflow image vetting to validate command

### DIFF
--- a/reana_client/validation/environments.py
+++ b/reana_client/validation/environments.py
@@ -20,7 +20,6 @@ from reana_commons.config import (
 )
 from reana_commons.utils import run_command
 
-
 from reana_client.errors import EnvironmentValidationError
 from reana_client.config import (
     DOCKER_REGISTRY_INDEX_URL,
@@ -28,11 +27,12 @@ from reana_client.config import (
     ENVIRONMENT_IMAGE_SUSPECTED_TAGS_VALIDATOR,
     GITLAB_CERN_REGISTRY_INDEX_URL,
     GITLAB_CERN_REGISTRY_PREFIX,
+    ERROR_MESSAGES,
 )
 from reana_client.printer import display_message
 
 
-def validate_environment(reana_yaml, pull=False):
+def validate_environment(reana_yaml, pull=False, access_token=None):
     """Validate environments in REANA specification file according to workflow type.
 
     :param reana_yaml: Dictionary which represents REANA specification file.
@@ -43,17 +43,23 @@ def validate_environment(reana_yaml, pull=False):
         workflow_type = workflow["type"]
         if workflow_type == "serial":
             workflow_steps = workflow["specification"]["steps"]
-            return EnvironmentValidatorSerial(workflow_steps=workflow_steps, pull=pull)
+            return EnvironmentValidatorSerial(
+                workflow_steps=workflow_steps, pull=pull, access_token=access_token
+            )
         if workflow_type == "yadage":
             workflow_steps = workflow["specification"]["stages"]
-            return EnvironmentValidatorYadage(workflow_steps=workflow_steps, pull=pull)
+            return EnvironmentValidatorYadage(
+                workflow_steps=workflow_steps, pull=pull, access_token=access_token
+            )
         if workflow_type == "cwl":
             workflow_steps = workflow.get("specification", {}).get("$graph", workflow)
-            return EnvironmentValidatorCWL(workflow_steps=workflow_steps, pull=pull)
+            return EnvironmentValidatorCWL(
+                workflow_steps=workflow_steps, pull=pull, access_token=access_token
+            )
         if workflow_type == "snakemake":
             workflow_steps = workflow["specification"]["steps"]
             return EnvironmentValidatorSnakemake(
-                workflow_steps=workflow_steps, pull=pull
+                workflow_steps=workflow_steps, pull=pull, access_token=access_token
             )
 
     workflow = reana_yaml["workflow"]
@@ -65,7 +71,7 @@ def validate_environment(reana_yaml, pull=False):
 class EnvironmentValidatorBase:
     """REANA workflow environments validation base class."""
 
-    def __init__(self, workflow_steps=None, pull=False):
+    def __init__(self, workflow_steps=None, pull=False, access_token=None):
         """Validate environments in REANA workflow.
 
         :param workflow_steps: List of dictionaries which represents different steps involved in workflow.
@@ -73,8 +79,10 @@ class EnvironmentValidatorBase:
         """
         self.workflow_steps = workflow_steps
         self.pull = pull
+        self.access_token = access_token
         self.validated_images = set()
         self.messages = []
+        self._vetting_config = None  # cached (vetting_enabled, allowlist); False = skip
 
     def validate(self):
         """Validate REANA workflow environments."""
@@ -98,15 +106,63 @@ class EnvironmentValidatorBase:
                 indented=True,
             )
 
+    def check_image_authorized(self, image):
+        """Checks if an image is authorized for use in workflows.
+
+        :param image: Full image name with tag.
+        """
+        if self._vetting_config is False:
+            return  # There was no token or fetch error, skip
+
+        if not self.access_token:
+            self.messages.append(
+                {
+                    "type": "warning",
+                    "message": f'No access token provided - skipping container image authorisation check. {ERROR_MESSAGES["missing_access_token"]}',
+                }
+            )
+            self._vetting_config = False
+            return
+
+        if self._vetting_config is None:
+            # Vetting config has not been cached yet - fetch and cache
+            try:
+                from reana_client.api.client import info
+
+                cluster_info = info(self.access_token)
+                vetting = cluster_info.get("vetted_container_images_enabled")
+                allowlist = cluster_info.get("vetted_container_images_allowlist")
+                if vetting is None or allowlist is None:
+                    # Server predates vetting support (skip the image vetting check)
+                    self._vetting_config = False
+                    return
+                self._vetting_config = (vetting["value"], allowlist["value"])
+            except Exception as e:
+                self.messages.append(
+                    {
+                        "type": "warning",
+                        "message": f"Could not check if container images are authorised. Is the cluster running properly? Error: {e}",
+                    }
+                )
+                self._vetting_config = False
+                return
+
+        # Validate image against allowlist
+        vetting_enabled, allowlist = self._vetting_config
+        if vetting_enabled and image not in allowlist:
+            raise EnvironmentValidationError(
+                f"Environment image is not allowed: {image}"
+            )
+
     def _validate_environment_image(self, image, kubernetes_uid=None):
         """Validate image environment.
 
         :param image: Full image name with tag if specified.
         :param kubernetes_uid: Kubernetes UID defined in workflow spec.
         """
-
         if image not in self.validated_images:
             image_name, image_tag = self._validate_image_tag(image)
+            self.check_image_authorized(image)
             exists_locally, _ = self._image_exists(image_name, image_tag)
             if exists_locally or self.pull:
                 uid, gids = self._get_image_uid_gids(image_name, image_tag)
@@ -415,18 +471,9 @@ class EnvironmentValidatorYadage(EnvironmentValidatorBase):
 
     def _extract_steps_environments(self):
         """Extract environments yadage workflow steps."""
+        from reana_commons.validation.images import iter_yadage_environments
 
-        def traverse_yadage_workflow(stages):
-            environments = []
-            for stage in stages:
-                if "workflow" in stage["scheduler"]:
-                    nested_stages = stage["scheduler"]["workflow"].get("stages", {})
-                    environments += traverse_yadage_workflow(nested_stages)
-                else:
-                    environments.append(stage["scheduler"]["step"]["environment"])
-            return environments
-
-        return traverse_yadage_workflow(self.workflow_steps)
+        return list(iter_yadage_environments(self.workflow_steps))
 
     def validate_environment(self):
         """Validate environments in REANA yadage workflow."""
@@ -467,21 +514,10 @@ class EnvironmentValidatorCWL(EnvironmentValidatorBase):
 
     def validate_environment(self):
         """Validate environments in REANA CWL workflow."""
+        from reana_commons.validation.images import extract_cwl_images
 
-        def _validate_workflow_environment(workflow_steps):
-            """Validate environments in REANA CWL workflow steps."""
-            requirements = workflow_steps.get("requirements", [])
-            images = list(filter(lambda req: "dockerPull" in req, requirements))
-
-            for image in images:
-                self._validate_environment_image(image["dockerPull"])
-
-        workflow = self.workflow_steps
-        if isinstance(workflow, dict):
-            _validate_workflow_environment(workflow)
-        elif isinstance(workflow, list):
-            for wf in workflow:
-                _validate_workflow_environment(wf)
+        for image in extract_cwl_images(self.workflow_steps):
+            self._validate_environment_image(image)
 
 
 class EnvironmentValidatorSnakemake(EnvironmentValidatorBase):
@@ -498,6 +534,6 @@ class EnvironmentValidatorSnakemake(EnvironmentValidatorBase):
                         "message": f"Environment image not specified, using {REANA_DEFAULT_SNAKEMAKE_ENV_IMAGE}.",
                     }
                 )
-                image = REANA_DEFAULT_SNAKEMAKE_ENV_IMAGE
+                continue
             kubernetes_uid = step.get("kubernetes_uid")
             self._validate_environment_image(image, kubernetes_uid=kubernetes_uid)

--- a/reana_client/validation/utils.py
+++ b/reana_client/validation/utils.py
@@ -106,7 +106,9 @@ def validate_reana_spec(
             "Verifying environments in REANA specification file...",
             msg_type="info",
         )
-        validate_environment(reana_yaml, pull=pull_environment_image)
+        validate_environment(
+            reana_yaml, pull=pull_environment_image, access_token=access_token
+        )
 
 
 def _validate_server_capabilities(reana_yaml: Dict, access_token: str) -> None:
@@ -129,6 +131,48 @@ def _validate_server_capabilities(reana_yaml: Dict, access_token: str) -> None:
     root_path = reana_yaml.get("workspace", {}).get("root_path")
     available_workspaces = info_response.get("workspaces_available", {}).get("value")
     _validate_workspace(root_path, available_workspaces)
+
+    _validate_vetted_images(reana_yaml, info_response)
+
+
+def _validate_vetted_images(reana_yaml: Dict, info_response: Dict) -> None:
+    """Validate container images against the server's vetted images allowlist.
+
+    :param reana_yaml: dictionary which represents REANA specification file.
+    :param info_response: info endpoint response from the server.
+    """
+    from reana_commons.validation.images import extract_images
+
+    vetting_info = info_response.get("vetted_container_images_enabled")
+    allowlist_info = info_response.get("vetted_container_images_allowlist")
+    if vetting_info is None or allowlist_info is None:
+        return  # Server predates vetting support
+    if not vetting_info["value"]:
+        return  # Container image vetting is disabled
+
+    allowlist = allowlist_info["value"]
+    display_message(
+        "Verifying container images in REANA specification file...",
+        msg_type="info",
+    )
+    disallowed_images = [
+        image
+        for image in extract_images(reana_yaml)
+        if image and image not in allowlist
+    ]
+    if disallowed_images:
+        for image in disallowed_images:
+            display_message(
+                f"Environment image is not allowed: {image}",
+                msg_type="error",
+                indented=True,
+            )
+        sys.exit(1)
+    display_message(
+        "Workflow container images appear to be valid.",
+        msg_type="success",
+        indented=True,
+    )
 
 
 def validate_input_parameters(live_parameters, original_parameters):

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ extras_require = {
         "sphinx-click>=1.0.4",
     ],
     "tests": [
-        "reana-commons[kubernetes,tests]>=0.95.0a17,<0.96.0",
+        "reana-commons[kubernetes,tests]>=0.95.0a20,<0.96.0",
     ],
 }
 
@@ -41,7 +41,7 @@ install_requires = [
     "pathspec>=0.9.0,<1.0 ; python_version<'3.9'",
     "pathspec>=0.9.0 ; python_version>='3.9'",
     "jsonpointer>=2.0",
-    "reana-commons[yadage,snakemake,cwl]>=0.95.0a17,<0.96.0",
+    "reana-commons[yadage,snakemake,cwl]>=0.95.0a20,<0.96.0",
     "tablib>=0.12.1,<0.13",
     "werkzeug>=0.14.1 ; python_version<'3.10'",
     "werkzeug>=0.15.0 ; python_version>='3.10'",

--- a/tests/test_cli_workflows.py
+++ b/tests/test_cli_workflows.py
@@ -694,6 +694,27 @@ def test_workflow_create_not_valid_name(create_yaml_workflow_schema):
     assert result.exit_code == 1
 
 
+def test_workflow_create_image_not_authorized(create_yaml_workflow_schema):
+    """Test that create exits with code 1 when the workflow image is not in the allowlist."""
+    env = {"REANA_SERVER_URL": "localhost"}
+    reana_token = "000000"
+    mock_cluster_info = {
+        "compute_backends": {"value": ["kubernetes"]},
+        "vetted_container_images_enabled": {"value": True},
+        "vetted_container_images_allowlist": {"value": ["ubuntu:20.04"]},
+    }
+    runner = CliRunner(env=env)
+    with runner.isolated_filesystem():
+        with open("reana.yaml", "w") as f:
+            f.write(create_yaml_workflow_schema)
+        with patch("reana_client.api.client.info", return_value=mock_cluster_info):
+            result = runner.invoke(
+                cli, ["create", "-t", reana_token, "--file", "reana.yaml"]
+            )
+    assert result.exit_code == 1
+    assert "Environment image is not allowed" in result.output
+
+
 def test_create_workflow_from_json(create_yaml_workflow_schema):
     """Test create workflow from json specification."""
     status_code = 201
@@ -899,6 +920,42 @@ def test_workflows_validate(create_yaml_workflow_schema):
         )
         assert result.exit_code == 0
         assert message in result.output
+
+
+def test_workflows_validate_image_not_authorized(create_yaml_workflow_schema):
+    """Test that validate exits with code 1 when the workflow image is not in the allowlist."""
+    from reana_client.validation.environments import EnvironmentValidatorSerial
+
+    env = {"REANA_SERVER_URL": "localhost"}
+    reana_token = "000000"
+    mock_cluster_info = {
+        "vetted_container_images_enabled": {"value": True},
+        "vetted_container_images_allowlist": {"value": ["ubuntu:20.04"]},
+    }
+    runner = CliRunner(env=env)
+    with runner.isolated_filesystem():
+        with open("reana.yaml", "w") as f:
+            f.write(create_yaml_workflow_schema)
+        with patch(
+            "reana_client.api.client.info", return_value=mock_cluster_info
+        ), patch.object(
+            EnvironmentValidatorSerial,
+            "_image_exists",
+            return_value=(False, True),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "validate",
+                    "--environments",
+                    "-t",
+                    reana_token,
+                    "--file",
+                    "reana.yaml",
+                ],
+            )
+        assert result.exit_code == 1
+        assert "Environment image is not allowed" in result.output
 
 
 def test_get_workflow_status_ok():

--- a/tests/test_validate_environments.py
+++ b/tests/test_validate_environments.py
@@ -81,3 +81,107 @@ def test_image_exists_in_dockerhub(full_image, expected_url):
     with patch("requests.get", get_mock):
         assert validator._image_exists_in_dockerhub(image, tag)
         get_mock.assert_called_once_with(expected_url)
+
+
+@pytest.mark.parametrize(
+    "access_token, vetting_enabled, allowlist, image, expected_message_type, expected_message_content, should_raise",
+    [
+        # Test case 1: No access token provided
+        (
+            None,
+            True,
+            ["python:3.8"],
+            "python:3.8",
+            "warning",
+            "No access token provided",
+            False,
+        ),
+        # Test case 2: Vetting enabled, image in allowlist
+        (
+            "test_token",
+            True,
+            ["python:3.8", "ubuntu:20.04"],
+            "python:3.8",
+            None,
+            None,
+            False,
+        ),
+        # Test case 3: Vetting enabled, image not in allowlist
+        (
+            "test_token",
+            True,
+            ["python:3.8", "ubuntu:20.04"],
+            "nginx:latest",
+            None,
+            "Environment image is not allowed: nginx:latest",
+            True,
+        ),
+        # Test case 4: Vetting disabled, image not in allowlist (should pass)
+        ("test_token", False, ["python:3.8"], "nginx:latest", None, None, False),
+        # Test case 5: Vetting enabled, empty allowlist
+        (
+            "test_token",
+            True,
+            [],
+            "python:3.8",
+            None,
+            "Environment image is not allowed: python:3.8",
+            True,
+        ),
+    ],
+)
+def test_check_vetting(
+    access_token,
+    vetting_enabled,
+    allowlist,
+    image,
+    expected_message_type,
+    expected_message_content,
+    should_raise,
+):
+    """Test the check_vetting function with various scenarios."""
+    validator = EnvironmentValidatorSerial(access_token=access_token)
+
+    mock_cluster_info = {
+        "vetted_container_images_enabled": {"value": vetting_enabled},
+        "vetted_container_images_allowlist": {"value": allowlist},
+    }
+
+    def _invoke():
+        if access_token:
+            with patch("reana_client.api.client.info", return_value=mock_cluster_info):
+                validator.check_image_authorized(image)
+        else:
+            validator.check_image_authorized(image)
+
+    if should_raise:
+        with pytest.raises(EnvironmentValidationError) as exc_info:
+            _invoke()
+        assert expected_message_content in str(exc_info.value)
+    else:
+        _invoke()
+        if expected_message_type is None:
+            assert len(validator.messages) == 0
+        else:
+            assert len(validator.messages) == 1
+            message = validator.messages[0]
+            assert message["type"] == expected_message_type
+            assert expected_message_content in message["message"]
+
+
+def test_check_vetting_api_error():
+    """Test check_vetting function when API call fails."""
+    validator = EnvironmentValidatorSerial(access_token="test_token")
+
+    # Mock the info function to raise an exception
+    with patch(
+        "reana_client.api.client.info", side_effect=Exception("API connection failed")
+    ):
+        validator.check_image_authorized("python:3.8")
+
+    # Check that a warning message was added
+    assert len(validator.messages) == 1
+    message = validator.messages[0]
+    assert message["type"] == "warning"
+    assert "Could not check if container images are authorised" in message["message"]
+    assert "API connection failed" in message["message"]


### PR DESCRIPTION
Extend `reana-client validate` to check if container images used in workflows are authorized to run on the cluster. The list of authorized images is obtained from the `reana-server` `info` endpoint.

Closes reanahub/reana-server/issues/728