### PR TITLE
feat(workflow): add JSON output for sharing commands 

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -7,6 +7,7 @@ The list of contributors in alphabetical order:
 - [Alp Tuna](https://orcid.org/0009-0001-1915-3993)
 - [Anton Khodak](https://orcid.org/0000-0003-3263-4553)
 - [Audrius Mecionis](https://orcid.org/0000-0002-3759-1663)
+- [Cameron McClymont](https://orcid.org/0009-0002-0176-5251)
 - [Camila Diaz](https://orcid.org/0000-0001-5543-797X)
 - [Clemens Lange](https://orcid.org/0000-0002-3632-3157)
 - [Daan Rosendal](https://orcid.org/0000-0002-3447-9000)

--- a/reana_client/cli/workflow.py
+++ b/reana_client/cli/workflow.py
@@ -45,6 +45,7 @@ from reana_client.config import (
     CLI_LOGS_FOLLOW_DEFAULT_INTERVAL,
     MAX_RUN_LABELS_SHOWN,
     CLI_WORKFLOWS_LIST_MAX_RESULTS,
+    JSON,
 )
 from reana_client.printer import display_message
 from reana_client.utils import (
@@ -1751,19 +1752,24 @@ def workflow_close_interactive_session(workflow, access_token):  # noqa: D301
     type=click.DateTime(formats=["%Y-%m-%d"]),
     help="Optional date when access to the workflow will expire for the given user(s) (format: YYYY-MM-DD).",
 )
+@click.option(
+    "--json",
+    "output_format",
+    flag_value="json",
+    default=None,
+    help="Get output in JSON format.",
+)
 @click.pass_context
 def workflow_share_add(
-    ctx, workflow, access_token, users, message, valid_until
+    ctx, workflow, access_token, users, message, valid_until, output_format
 ):  # noqa D412
     """Share a workflow with other users (read-only).
 
     The `share-add` command allows sharing a workflow with other users. The
     users will be able to view the workflow but not modify it.
 
-    Examples:
-
-    \t $ reana-client share-add -w myanalysis.42 --user bob@example.org
-
+    Examples:\n
+    \t $ reana-client share-add -w myanalysis.42 --user bob@example.org\n
     \t $ reana-client share-add -w myanalysis.42 --user bob@example.org --user cecile@example.org --message "Please review my analysis" --valid-until 2025-12-31
     """
     from reana_client.api.client import share_workflow
@@ -1789,14 +1795,24 @@ def workflow_share_add(
             share_errors.append(f"Failed to share {workflow} with {user}: {str(e)}")
             logging.debug(traceback.format_exc())
 
-    if shared_users:
+    if output_format == JSON:
+        result = {
+            "workflow": workflow,
+            "shared_with": shared_users,
+            "errors": share_errors,
+        }
         display_message(
-            f"{workflow} is now read-only shared with {', '.join(shared_users)}",
-            msg_type="success",
+            json.dumps(result, indent=2),
         )
+    else:
+        if shared_users:
+            display_message(
+                f"{workflow} is now read-only shared with {', '.join(shared_users)}",
+                msg_type="success",
+            )
 
-    for error in share_errors:
-        display_message(error, msg_type="error")
+        for error in share_errors:
+            display_message(error, msg_type="error")
 
     if share_errors:
         sys.exit(1)
@@ -1814,16 +1830,24 @@ def workflow_share_add(
     help="Users to unshare the workflow with.",
     required=True,
 )
+@click.option(
+    "--json",
+    "output_format",
+    flag_value="json",
+    default=None,
+    help="Get output in JSON format.",
+)
 @click.pass_context
-def share_workflow_remove(ctx, workflow, access_token, users):  # noqa D412
+def share_workflow_remove(
+    ctx, workflow, access_token, users, output_format
+):  # noqa D412
     """Unshare a workflow.
 
     The `share-remove` command allows for unsharing a workflow. The workflow
     will no longer be visible to the users with whom it was shared.
 
-    Example:
-
-        $ reana-client share-remove -w myanalysis.42 --user bob@example.org
+    Example:\n
+    \t $ reana-client share-remove -w myanalysis.42 --user bob@example.org
     """
     from reana_client.api.client import unshare_workflow
 
@@ -1839,14 +1863,25 @@ def share_workflow_remove(ctx, workflow, access_token, users):  # noqa D412
             unshare_errors.append(f"Failed to unshare {workflow} with {user}: {str(e)}")
             logging.debug(traceback.format_exc())
 
-    if unshared_users:
+    if output_format == JSON:
+        result = {
+            "workflow": workflow,
+            "unshared_with": unshared_users,
+            "errors": unshare_errors,
+        }
         display_message(
-            f"{workflow} is no longer shared with {', '.join(unshared_users)}",
-            msg_type="success",
+            json.dumps(result, indent=2),
         )
-    if unshare_errors:
+    else:
+        if unshared_users:
+            display_message(
+                f"{workflow} is no longer shared with {', '.join(unshared_users)}",
+                msg_type="success",
+            )
         for error in unshare_errors:
             display_message(error, msg_type="error")
+
+    if unshare_errors:
         sys.exit(1)
 
 
@@ -1900,16 +1935,23 @@ def share_workflow_status(
     shared_with = sharing_status.get("shared_with", [])
     if shared_with:
         headers = ["user_email", "valid_until"]
-        data = [
-            [
-                entry["user_email"],
-                (entry["valid_until"] if entry["valid_until"] is not None else "-"),
+        if output_format == JSON:
+            data = [
+                [entry["user_email"], entry["valid_until"]] for entry in shared_with
             ]
-            for entry in shared_with
-        ]
-
+        else:
+            data = [
+                [
+                    entry["user_email"],
+                    (entry["valid_until"] if entry["valid_until"] is not None else "-"),
+                ]
+                for entry in shared_with
+            ]
         display_formatted_output(data, headers, format_, output_format)
     else:
-        display_message(
-            f"Workflow {workflow} is not shared with anyone.", msg_type="info"
-        )
+        if output_format == JSON:
+            display_message(json.dumps([]))
+        else:
+            display_message(
+                f"Workflow {workflow} is not shared with anyone.", msg_type="info"
+            )

--- a/tests/test_cli_workflows.py
+++ b/tests/test_cli_workflows.py
@@ -1496,3 +1496,368 @@ def test_share_status_workflow():
             )
             assert result.exit_code == 0
             assert response["message"] in result.output
+
+
+# ---------------------------
+# share-add JSON output tests
+# ---------------------------
+
+
+def test_share_add_workflow_json_success():
+    """Test share-add --json outputs valid JSON on success."""
+    status_code = 200
+    response = {
+        "message": "is now read-only shared with",
+        "workflow_id": "string",
+        "workflow_name": "string",
+    }
+    env = {"REANA_SERVER_URL": "localhost"}
+    mock_http_response = Mock()
+    mock_http_response.status_code = status_code
+    reana_token = "000000"
+    runner = CliRunner(env=env)
+    with runner.isolation():
+        with patch(
+            "reana_client.api.client.current_rs_api_client",
+            make_mock_api_client("reana-server")(response, mock_http_response),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "share-add",
+                    "--json",
+                    "-t",
+                    reana_token,
+                    "--workflow",
+                    "test-workflow.1",
+                    "--user",
+                    "bob@example.org",
+                ],
+            )
+            assert result.exit_code == 0
+            parsed = json.loads(result.output)
+            assert parsed["workflow"] == "test-workflow.1"
+            assert parsed["shared_with"] == ["bob@example.org"]
+            assert parsed["errors"] == []
+
+
+def test_share_add_workflow_json_all_fail():
+    """Test share-add --json outputs errors and exits 1 when all shares fail."""
+    env = {"REANA_SERVER_URL": "localhost"}
+    reana_token = "000000"
+    runner = CliRunner(env=env)
+    with runner.isolation():
+        with patch(
+            "reana_client.api.client.share_workflow",
+            side_effect=Exception("User not found"),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "share-add",
+                    "--json",
+                    "-t",
+                    reana_token,
+                    "--workflow",
+                    "test-workflow.1",
+                    "--user",
+                    "nobody@example.org",
+                ],
+            )
+            assert result.exit_code == 1
+            parsed = json.loads(result.output)
+            assert parsed["workflow"] == "test-workflow.1"
+            assert parsed["shared_with"] == []
+            assert len(parsed["errors"]) == 1
+            assert "nobody@example.org" in parsed["errors"][0]
+
+
+def test_share_add_workflow_json_partial_failure():
+    """Test share-add --json reports partial results and exits 1 on any error."""
+    env = {"REANA_SERVER_URL": "localhost"}
+    reana_token = "000000"
+    runner = CliRunner(env=env)
+    with runner.isolation():
+        with patch(
+            "reana_client.api.client.share_workflow",
+            side_effect=[None, Exception("User not found")],
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "share-add",
+                    "--json",
+                    "-t",
+                    reana_token,
+                    "--workflow",
+                    "test-workflow.1",
+                    "--user",
+                    "bob@example.org",
+                    "--user",
+                    "nobody@example.org",
+                ],
+            )
+            assert result.exit_code == 1
+            parsed = json.loads(result.output)
+            assert parsed["shared_with"] == ["bob@example.org"]
+            assert len(parsed["errors"]) == 1
+            assert "nobody@example.org" in parsed["errors"][0]
+
+
+# ------------------------------
+# share-remove JSON output tests
+# ------------------------------
+
+
+def test_share_remove_workflow_json_success():
+    """Test share-remove --json outputs valid JSON on success."""
+    status_code = 200
+    response = {
+        "message": "is no longer shared with",
+        "workflow_id": "string",
+        "workflow_name": "string",
+    }
+    env = {"REANA_SERVER_URL": "localhost"}
+    mock_http_response = Mock()
+    mock_http_response.status_code = status_code
+    reana_token = "000000"
+    runner = CliRunner(env=env)
+    with runner.isolation():
+        with patch(
+            "reana_client.api.client.current_rs_api_client",
+            make_mock_api_client("reana-server")(response, mock_http_response),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "share-remove",
+                    "--json",
+                    "-t",
+                    reana_token,
+                    "--workflow",
+                    "test-workflow.1",
+                    "--user",
+                    "bob@example.org",
+                ],
+            )
+            assert result.exit_code == 0
+            parsed = json.loads(result.output)
+            assert parsed["workflow"] == "test-workflow.1"
+            assert parsed["unshared_with"] == ["bob@example.org"]
+            assert parsed["errors"] == []
+
+
+def test_share_remove_workflow_json_all_fail():
+    """Test share-remove --json outputs errors and exits 1 when all unshares fail."""
+    env = {"REANA_SERVER_URL": "localhost"}
+    reana_token = "000000"
+    runner = CliRunner(env=env)
+    with runner.isolation():
+        with patch(
+            "reana_client.api.client.unshare_workflow",
+            side_effect=Exception("Workflow not shared with user"),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "share-remove",
+                    "--json",
+                    "-t",
+                    reana_token,
+                    "--workflow",
+                    "test-workflow.1",
+                    "--user",
+                    "nobody@example.org",
+                ],
+            )
+            assert result.exit_code == 1
+            parsed = json.loads(result.output)
+            assert parsed["workflow"] == "test-workflow.1"
+            assert parsed["unshared_with"] == []
+            assert len(parsed["errors"]) == 1
+            assert "nobody@example.org" in parsed["errors"][0]
+
+
+def test_share_remove_workflow_json_partial_failure():
+    """Test share-remove --json reports partial results and exits 1 on any error."""
+    env = {"REANA_SERVER_URL": "localhost"}
+    reana_token = "000000"
+    runner = CliRunner(env=env)
+    with runner.isolation():
+        with patch(
+            "reana_client.api.client.unshare_workflow",
+            side_effect=[None, Exception("Workflow not shared with user")],
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "share-remove",
+                    "--json",
+                    "-t",
+                    reana_token,
+                    "--workflow",
+                    "test-workflow.1",
+                    "--user",
+                    "bob@example.org",
+                    "--user",
+                    "nobody@example.org",
+                ],
+            )
+            assert result.exit_code == 1
+            parsed = json.loads(result.output)
+            assert parsed["unshared_with"] == ["bob@example.org"]
+            assert len(parsed["errors"]) == 1
+            assert "nobody@example.org" in parsed["errors"][0]
+
+
+# ------------------------------
+# share-status JSON output tests
+# ------------------------------
+
+
+def test_share_status_workflow_json_success():
+    """Test share-status --json outputs a JSON array when workflow is shared."""
+    status_code = 200
+    response = {
+        "shared_with": [
+            {"user_email": "bob@example.org", "valid_until": "2025-12-31"},
+            {"user_email": "alice@example.org", "valid_until": None},
+        ]
+    }
+    env = {"REANA_SERVER_URL": "localhost"}
+    mock_http_response = Mock()
+    mock_http_response.status_code = status_code
+    reana_token = "000000"
+    runner = CliRunner(env=env)
+    with runner.isolation():
+        with patch(
+            "reana_client.api.client.current_rs_api_client",
+            make_mock_api_client("reana-server")(response, mock_http_response),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "share-status",
+                    "--json",
+                    "-t",
+                    reana_token,
+                    "--workflow",
+                    "test-workflow.1",
+                ],
+            )
+            assert result.exit_code == 0
+            parsed = json.loads(result.output)
+            assert isinstance(parsed, list)
+            assert len(parsed) == 2
+            by_email = {row["user_email"]: row for row in parsed}
+            assert by_email["bob@example.org"]["valid_until"] == "2025-12-31"
+            assert by_email["alice@example.org"]["valid_until"] is None
+
+
+def test_share_status_workflow_json_empty():
+    """Test share-status --json outputs valid JSON when workflow is not shared."""
+    status_code = 200
+    response = {
+        "message": "is not shared with anyone",
+        "workflow_id": "string",
+        "workflow_name": "string",
+    }
+    env = {"REANA_SERVER_URL": "localhost"}
+    mock_http_response = Mock()
+    mock_http_response.status_code = status_code
+    reana_token = "000000"
+    runner = CliRunner(env=env)
+    with runner.isolation():
+        with patch(
+            "reana_client.api.client.current_rs_api_client",
+            make_mock_api_client("reana-server")(response, mock_http_response),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "share-status",
+                    "--json",
+                    "-t",
+                    reana_token,
+                    "--workflow",
+                    "test-workflow.1",
+                ],
+            )
+            assert result.exit_code == 0
+            parsed = json.loads(result.output)
+            assert parsed == []
+
+
+def test_share_status_workflow_error_exits_nonzero():
+    """Test share-status exits 1 when the API call fails."""
+    env = {"REANA_SERVER_URL": "localhost"}
+    reana_token = "000000"
+    runner = CliRunner(env=env)
+    with runner.isolation():
+        with patch(
+            "reana_client.api.client.get_workflow_sharing_status",
+            side_effect=Exception("Workflow not found"),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "share-status",
+                    "-t",
+                    reana_token,
+                    "--workflow",
+                    "nonexistent-workflow.1",
+                ],
+            )
+            assert result.exit_code == 1
+
+
+def test_share_add_workflow_text_error_exits_nonzero():
+    """Test share-add exits 1 (text mode) when the API call fails."""
+    env = {"REANA_SERVER_URL": "localhost"}
+    reana_token = "000000"
+    runner = CliRunner(env=env)
+    with runner.isolation():
+        with patch(
+            "reana_client.api.client.share_workflow",
+            side_effect=Exception("User not found"),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "share-add",
+                    "-t",
+                    reana_token,
+                    "--workflow",
+                    "test-workflow.1",
+                    "--user",
+                    "nobody@example.org",
+                ],
+            )
+            assert result.exit_code == 1
+            assert "nobody@example.org" in result.output
+
+
+def test_share_remove_workflow_text_error_exits_nonzero():
+    """Test share-remove exits 1 (text mode) when the API call fails."""
+    env = {"REANA_SERVER_URL": "localhost"}
+    reana_token = "000000"
+    runner = CliRunner(env=env)
+    with runner.isolation():
+        with patch(
+            "reana_client.api.client.unshare_workflow",
+            side_effect=Exception("Workflow not shared with user"),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "share-remove",
+                    "-t",
+                    reana_token,
+                    "--workflow",
+                    "test-workflow.1",
+                    "--user",
+                    "nobody@example.org",
+                ],
+            )
+            assert result.exit_code == 1
+            assert "nobody@example.org" in result.output


### PR DESCRIPTION
Add JSON output support to the share-add and share-remove commands.
Return an empty JSON array from share-status when no users are present.
Add tests for successful, failed, and partially successful operations.

Closes #712