### PR TITLE
feat(utils): show Dask service logs

### DIFF
--- a/reana_client/cli/utils.py
+++ b/reana_client/cli/utils.py
@@ -364,6 +364,34 @@ def output_user_friendly_logs(workflow_logs, steps):
         click.secho(f"{leading_mark} Engine internal logs", fg="yellow")
         click.secho(workflow_logs["engine_specific"])
 
+    # Service logs (e.g. Dask scheduler/worker pod logs)
+    service_logs = workflow_logs.get("service_logs", {})
+    service_names = sorted(
+        service_name for service_name, entries in service_logs.items() if entries
+    )
+    if service_names:
+        click.echo("\n")
+        click.secho(f"{leading_mark} Service logs", bold=True, fg="yellow")
+        for service_name in service_names:
+            entries = service_logs[service_name]
+            click.secho(
+                f"{leading_mark} Service: {service_name}",
+                bold=True,
+                fg="yellow",
+            )
+            for entry in entries:
+                component = entry.get("component", "")
+                content = entry.get("content", "")
+                click.secho(f"{leading_mark} Component: {component}", fg="yellow")
+                if content:
+                    click.secho(f"{leading_mark} Logs:", fg="yellow")
+                    click.secho(content)
+                else:
+                    display_message(
+                        f"Component {component} emitted no logs.",
+                        msg_type="info",
+                    )
+
     returned_step_names = set(
         workflow_logs["job_logs"][item]["job_name"]
         for item in workflow_logs["job_logs"].keys()

--- a/tests/test_cli_utils.py
+++ b/tests/test_cli_utils.py
@@ -383,6 +383,21 @@ def test_output_user_friendly_logs_basic_output(capsys):
     assert "Step: step1" in out
 
 
+def test_output_user_friendly_logs_empty_service_logs(capsys):
+    workflow_logs = {
+        "workflow_logs": "ENGINE LOG\n",
+        "job_logs": {},
+        "service_logs": {"dask-service-123": []},
+    }
+
+    cli_utils.output_user_friendly_logs(workflow_logs, steps=None)
+
+    out = capsys.readouterr().out
+    assert "Workflow engine logs" in out
+    assert "Service logs" not in out
+    assert "Service: dask-service-123" not in out
+
+
 def test_retrieve_workflow_logs_calls_output_user_friendly_logs(monkeypatch):
     payload = {
         "workflow_logs": "W",


### PR DESCRIPTION
The REST API already exposes Dask scheduler and worker pod logs under the `service_logs` key of the workflow logs response, and the Web UI surfaces them in a dedicated tab. The CLI silently dropped the field, leaving Dask users without a terminal-side view of their cluster logs.

Render the captured pod logs in `reana-client logs` after the workflow engine logs and before the job logs.

Closes #768