### PR TITLE
refactor(pytest): drop pytest-reana for reana-commons[tests]

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,8 +26,7 @@ extras_require = {
         "sphinx-click>=1.0.4",
     ],
     "tests": [
-        "pytest-reana>=0.95.0a6,<0.96.0",
-        "reana-commons[kubernetes]>=0.95.0a14,<0.96.0",
+        "reana-commons[kubernetes,tests]>=0.95.0a17,<0.96.0",
     ],
 }
 
@@ -42,7 +41,7 @@ install_requires = [
     "pathspec>=0.9.0,<1.0 ; python_version<'3.9'",
     "pathspec>=0.9.0 ; python_version>='3.9'",
     "jsonpointer>=2.0",
-    "reana-commons[yadage,snakemake,cwl]>=0.95.0a14,<0.96.0",
+    "reana-commons[yadage,snakemake,cwl]>=0.95.0a17,<0.96.0",
     "tablib>=0.12.1,<0.13",
     "werkzeug>=0.14.1 ; python_version<'3.10'",
     "werkzeug>=0.15.0 ; python_version>='3.10'",

--- a/tests/test_cli_files.py
+++ b/tests/test_cli_files.py
@@ -16,7 +16,7 @@ import zipfile
 
 from click.testing import CliRunner
 from mock import Mock, patch
-from pytest_reana.test_utils import make_mock_api_client
+from reana_commons.testing import make_mock_api_client
 from reana_client.cli import cli
 
 

--- a/tests/test_cli_ping.py
+++ b/tests/test_cli_ping.py
@@ -10,7 +10,7 @@
 
 from click.testing import CliRunner
 from mock import Mock, patch
-from pytest_reana.test_utils import make_mock_api_client
+from reana_commons.testing import make_mock_api_client
 
 from reana_client.cli import cli
 from reana_client.config import ERROR_MESSAGES

--- a/tests/test_cli_secrets.py
+++ b/tests/test_cli_secrets.py
@@ -12,7 +12,7 @@ import pytest
 from bravado.exception import HTTPError
 from click.testing import CliRunner
 from mock import Mock, patch
-from pytest_reana.test_utils import make_mock_api_client
+from reana_commons.testing import make_mock_api_client
 
 from reana_client.cli import cli
 

--- a/tests/test_cli_workflows.py
+++ b/tests/test_cli_workflows.py
@@ -18,7 +18,7 @@ import pytest
 import yaml
 from click.testing import CliRunner
 from mock import Mock, patch
-from pytest_reana.test_utils import make_mock_api_client
+from reana_commons.testing import make_mock_api_client
 from reana_client.api.client import create_workflow_from_json
 from reana_client.cli import cli
 from reana_client.config import RUN_STATUSES

--- a/tests/test_validate_server_capabilities.py
+++ b/tests/test_validate_server_capabilities.py
@@ -11,7 +11,7 @@
 import pytest
 from click.testing import CliRunner
 from mock import Mock, patch
-from pytest_reana.test_utils import make_mock_api_client
+from reana_commons.testing import make_mock_api_client
 
 from reana_client.cli import cli
 from reana_client.config import ERROR_MESSAGES


### PR DESCRIPTION
Replace pytest-reana in extras_require[tests] with the
reana-commons[kubernetes,tests] extra. The make_mock_api_client
helper imports in test_cli_ping.py, test_cli_secrets.py,
test_cli_files.py, test_validate_server_capabilities.py and
test_cli_workflows.py are rewritten to come from
reana_commons.testing. The client does not exercise any
DB-coupled fixture, so it does not need reana-db[tests].

Closes https://github.com/reanahub/pytest-reana/issues/156