### PR TITLE
test(snakemake): cover container image validation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ extras_require = {
         "sphinx-click>=1.0.4",
     ],
     "tests": [
-        "reana-commons[kubernetes,tests]>=0.95.0a20,<0.96.0",
+        "reana-commons[kubernetes,tests]>=0.95.0a21,<0.96.0",
     ],
 }
 
@@ -41,7 +41,7 @@ install_requires = [
     "pathspec>=0.9.0,<1.0 ; python_version<'3.9'",
     "pathspec>=0.9.0 ; python_version>='3.9'",
     "jsonpointer>=2.0",
-    "reana-commons[yadage,snakemake,cwl]>=0.95.0a20,<0.96.0",
+    "reana-commons[yadage,snakemake,cwl]>=0.95.0a21,<0.96.0",
     "tablib>=0.12.1,<0.13",
     "werkzeug>=0.14.1 ; python_version<'3.10'",
     "werkzeug>=0.15.0 ; python_version>='3.10'",

--- a/tests/test_cli_workflows.py
+++ b/tests/test_cli_workflows.py
@@ -25,6 +25,8 @@ from reana_client.config import RUN_STATUSES
 from reana_client.utils import get_workflow_status_change_msg
 from reana_commons.api_client import BaseAPIClient
 from reana_commons.config import INTERACTIVE_SESSION_TYPES
+from reana_commons.specification import load_workflow_spec_from_reana_yaml
+from reana_commons.validation.images import extract_images
 
 
 def test_workflows_server_not_connected():
@@ -35,6 +37,28 @@ def test_workflows_server_not_connected():
     message = "REANA client is not connected to any REANA cluster."
     assert message in result.output
     assert result.exit_code == 1
+
+
+def test_load_snakemake_workflow_extracts_container_image(tmp_path):
+    """Test that client-side Snakemake expansion exposes container images."""
+    snakefile = tmp_path / "Snakefile"
+    snakefile.write_text("""
+rule all:
+    input: "output.txt"
+    default_target: True
+
+rule create_output:
+    output: "output.txt"
+    container: "docker://docker.io/library/ubuntu:24.04"
+    shell: "touch {output}"
+""")
+    reana_yaml = {"workflow": {"type": "snakemake", "file": "Snakefile"}}
+
+    reana_yaml["workflow"]["specification"] = load_workflow_spec_from_reana_yaml(
+        reana_yaml, tmp_path
+    )
+
+    assert extract_images(reana_yaml) == ["docker.io/library/ubuntu:24.04"]
 
 
 def test_workflows_no_token():


### PR DESCRIPTION
Verify that client-side workflow expansion exposes parsed Snakemake
container images for vetted-image validation.

Closes reanahub/reana-workflow-engine-snakemake#129

