### PR TITLE
ci(codecov): fix matrix condition for Codecov Coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -290,7 +290,7 @@ jobs:
         run: ./run-tests.sh --python-tests
 
       - name: Codecov Coverage
-        if: matrix.python == '3.12'
+        if: matrix.python-version == '3.12'
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
The coverage upload was guarded by `matrix.python`, but the matrix key is `matrix.python-version`, so the condition never evaluated to true.